### PR TITLE
(Slow) Recalculate function stack size whenever function is added or updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ __Now with partial support for PHP7.0!__ (This extension isn't production ready 
 Current Build Status
 --------------------
 
-In 7.0.x: Roughly 16 failing tests, 93 skipped tests, 79 passing tests.
+In 7.0.x: Roughly 12 failing tests, 93 skipped tests, 79 passing tests.
 
 In 7.1.0beta1: More segmentation faults and test failures than 7.0.x
 

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -213,6 +213,7 @@ static inline void *runkit_zend_hash_add_or_update_ptr(HashTable *ht, zend_strin
 #define RUNKIT_TEMP_FUNCNAME  "__runkit_temporary_function__"
 int php_runkit_check_call_stack(zend_op_array *op_array TSRMLS_DC);
 void php_runkit_clear_all_functions_runtime_cache(TSRMLS_D);
+void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, zend_function *called_f TSRMLS_DC);
 
 void php_runkit_remove_function_from_reflection_objects(zend_function *fe TSRMLS_DC);
 // void php_runkit_function_copy_ctor(zend_function *fe, zend_string *newname TSRMLS_DC);

--- a/tests/runkit_function_redefine_using_undef.phpt
+++ b/tests/runkit_function_redefine_using_undef.phpt
@@ -15,17 +15,19 @@ runkit_function_redefine('runkit_function',
 );
 echo "call\n";
 runkit_function('foo');
-echo "\nsecond call";
+echo "second call\n";
 runkit_function('foo', 'bar');
-echo "\nDone";
+echo "Done\n";
 ?>
---EXPECT--
+--EXPECTF--
 call
 var_dump
+
 Notice: Undefined variable: missing in %s on line %d
 NULL
 second call
 var_dump
+
 Notice: Undefined variable: missing in %s on line %d
 NULL
 Done

--- a/tests/runkit_method_remove_and_reflection_parameter_with_inheritance.phpt
+++ b/tests/runkit_method_remove_and_reflection_parameter_with_inheritance.phpt
@@ -28,7 +28,7 @@ try {
 }
 ?>
 --EXPECTREGEX--
-object\(ReflectionParameter\)#%d \(1\) {
+object\(ReflectionParameter\)#\d+ \(1\) {
   \["name"\]=>
   string\(31\) "__parameter_removed_by_runkit__"
 }


### PR DESCRIPTION
Fixes https://github.com/runkit7/runkit7/issues/24

This recalculates the hardcoded opcode stack size and replaces the stack size with that (if it increased)