### PR TITLE
WIP work on internal function manipulation, stop some cases which were segfaulting.

### DIFF
--- a/ci/generate_php_install_dir.sh
+++ b/ci/generate_php_install_dir.sh
@@ -1,6 +1,10 @@
 #!/bin/bash -xeu
 # Print a folder name based on the integer width(32 bit or 64 bit), whether or not NTS is used (implied by PHP_CONFIGURE_ARGS), and PHP_CONFIGURE_ARGS.
-PHP_INSTALL_DIR="$HOME/travis_cache/php-$PHP_NTS_VERSION"
+PHP_NTS_NORMAL_VERSION=${PHP_NTS_VERSION//RC[0-9]/}
+if [ "$PHP_NTS_NORMAL_VERSION" = "7.1.0" ]; then
+	PHP_NTS_NORMAL_VERSION=7.1.0RC1
+fi
+PHP_INSTALL_DIR="$HOME/travis_cache/php-$PHP_NTS_NORMAL_VERSION"
 if [ "${USE_32BIT:-0}" = "1" ]; then
 	PHP_INSTALL_DIR="$PHP_INSTALL_DIR-32bit"
 else

--- a/ci/get_global_php_version.sh
+++ b/ci/get_global_php_version.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-php -r "echo(str_replace('-dev','',PHP_VERSION));"
+php -r "echo(preg_replace('/-dev|RC.*/','',PHP_VERSION));"

--- a/ci/install_php_nts.sh
+++ b/ci/install_php_nts.sh
@@ -5,32 +5,28 @@ if [ "x$PHP_NTS_VERSION" = "x" -o "x$PHP_CONFIGURE_ARGS" = "x" ] ; then
 	echo "Missing nts version or configuration arguments";
 	exit 1;
 fi
-if [ "$PHP_NTS_VERSION" = "7.2.0" ]; then
-	# The travis nightlies are on 7.2.0 now, but php.net is on 7.1.0
-	PHP_NTS_VERSION=7.1.0
-fi
-PHP_FOLDER="php-$PHP_NTS_VERSION"
 PHP_INSTALL_DIR="$(./ci/generate_php_install_dir.sh)"
 echo "Downloading $PHP_INSTALL_DIR\n"
 if [ -x $PHP_INSTALL_DIR/bin/php ] ; then 
 	echo "PHP $PHP_NTS_VERSION already installed and in cache at $PHP_INSTALL_DIR";
 	exit 0
 fi
+PHP_NTS_NORMAL_VERSION=${PHP_NTS_VERSION//RC[0-9]/}
+PHP_FOLDER="php-$PHP_NTS_VERSION"
+
 # Remove cache if it somehow exists
 if [ "x${TRAVIS:-0}" != "x" ]; then
 	rm -rf $HOME/travis_cache/
 fi
 # Otherwise, put a minimal installation inside of the cache.
 PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-if [ "$PHP_NTS_VERSION" != "7.1.0" ] ; then
+if [ "$PHP_NTS_NORMAL_VERSION" != "7.1.0" ] ; then
 	curl --verbose https://secure.php.net/distributions/$PHP_TAR_FILE -o $PHP_TAR_FILE
 else
 	curl --verbose https://downloads.php.net/~davey/php-7.1.0RC1.tar.bz2 -o $PHP_TAR_FILE
+	PHP_FOLDER="php-7.1.0RC1"
 fi
 tar xjf $PHP_TAR_FILE
-if [ "$PHP_NTS_VERSION" = "7.1.0" ] ; then
-	mv "${PHP_FOLDER}beta1" "$PHP_FOLDER"
-fi
 
 pushd $PHP_FOLDER
 ./configure $PHP_CONFIGURE_ARGS --prefix="$PHP_INSTALL_DIR"

--- a/config.m4
+++ b/config.m4
@@ -47,5 +47,6 @@ if test "$PHP_RUNKIT" != "no"; then
 runkit_constants.c \
 runkit_object_id.c \
 runkit_common.c \
+runkit_zend_execute_API.c \
 , $ext_shared,, -Wdeclaration-after-statement -Werror -Wall -Wno-deprecated-declarations -Wno-pedantic)
 fi

--- a/config.w32
+++ b/config.w32
@@ -10,5 +10,5 @@ ARG_ENABLE("runkit-super", "Disable registration of user-defined autoglobals", "
 if (PHP_RUNKIT != "no") {
 	AC_DEFINE("PHP_RUNKIT_FEATURE_MODIFY", PHP_RUNKIT_MODIFY == "yes", "Runkit Manipulation");
 	AC_DEFINE("PHP_RUNKIT_FEATURE_SUPER", PHP_RUNKIT_SUPER == "yes", "Runkit Superglobals");
-	EXTENSION("runkit", "runkit.c runkit_functions.c runkit_methods.c runkit_constants.c runkit_object_id.c runkit_common.c");
+	EXTENSION("runkit", "runkit.c runkit_functions.c runkit_methods.c runkit_constants.c runkit_object_id.c runkit_common.c runkit_zend_execute_API.c");
 }

--- a/package.xml
+++ b/package.xml
@@ -218,7 +218,9 @@ Define customized superglobal variables for general purpose use.
    <file name="config.w32" role="src" />
    <file name="php_runkit.h" role="src" />
    <file name="php_runkit_hash.h" role="src" />
+   <file name="php_runkit_zend_execute_API.h" role="src" />
    <file name="php_runkit_zval.h" role="src" />
+   <file name="runkit_zend_execute_API.c" role="src" />
    <file name="LICENSE" role="doc" />
    <file name="README.md" role="doc" />
    <file name="runkit.c" role="src" />

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -217,13 +217,15 @@ void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, ze
 
 void php_runkit_remove_function_from_reflection_objects(zend_function *fe TSRMLS_DC);
 // void php_runkit_function_copy_ctor(zend_function *fe, zend_string *newname TSRMLS_DC);
-zend_function* php_runkit_function_clone(zend_function *fe, zend_string *newname TSRMLS_DC);
+zend_function* php_runkit_function_clone(zend_function *fe, zend_string *newname, char orig_fe_type TSRMLS_DC);
 void php_runkit_function_dtor(zend_function *fe);
+int php_runkit_remove_from_function_table(HashTable *function_table, zend_string *func_lower);
+void* php_runkit_update_function_table(HashTable *function_table, zend_string *func_lower, zend_function *f);
 int php_runkit_generate_lambda_method(const zend_string *arguments, const zend_string *phpcode,
                                       zend_function **pfe, zend_bool return_ref TSRMLS_DC);
 int php_runkit_cleanup_lambda_method();
 int php_runkit_destroy_misplaced_functions(zval *pDest TSRMLS_DC);
-int php_runkit_restore_internal_functions(RUNKIT_53_TSRMLS_ARG(zval *pDest), int num_args, va_list args, zend_hash_key *hash_key);
+int php_runkit_restore_internal_function(zend_string *fname_lower, zend_function *f);
 int php_runkit_clean_zval(zval **val TSRMLS_DC);
 
 /* runkit_methods.c */

--- a/php_runkit_zend_execute_API.h
+++ b/php_runkit_zend_execute_API.h
@@ -1,0 +1,5 @@
+#ifndef PHP_RUNKIT_ZEND_EXECUTE_API_H
+#define PHP_RUNKIT_ZEND_EXECUTE_API_H
+#include "Zend/zend.h"
+int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inner, INTERNAL_FUNCTION_PARAMETERS);
+#endif

--- a/runkit.c
+++ b/runkit.c
@@ -417,7 +417,14 @@ PHP_RSHUTDOWN_FUNCTION(runkit)
 
 	if (RUNKIT_G(replaced_internal_functions)) {
 		/* Restore internal functions */
-		zend_hash_apply_with_arguments(RUNKIT_53_TSRMLS_PARAM(RUNKIT_G(replaced_internal_functions)), php_runkit_restore_internal_functions, 1 RUNKIT_TSRMLS_C);
+		zend_function *f;
+		zend_string *key;
+		ZEND_HASH_FOREACH_STR_KEY_PTR(RUNKIT_G(replaced_internal_functions), key, f) {
+			if (key != NULL) {
+				ZEND_ASSERT(f->type == ZEND_INTERNAL_FUNCTION || f->type == ZEND_USER_FUNCTION);
+				php_runkit_restore_internal_function(key, f);
+			}
+		} ZEND_HASH_FOREACH_END();
 		zend_hash_destroy(RUNKIT_G(replaced_internal_functions));
 		FREE_HASHTABLE(RUNKIT_G(replaced_internal_functions));
 		RUNKIT_G(replaced_internal_functions) = NULL;

--- a/runkit_methods.c
+++ b/runkit_methods.c
@@ -370,7 +370,7 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 		remove_temp = 1;
 	}
 
-	func = php_runkit_function_clone(source_fe, methodname TSRMLS_CC);
+	func = php_runkit_function_clone(source_fe, methodname, (orig_fe ? orig_fe->type : ZEND_USER_FUNCTION) TSRMLS_CC);
 
 	if (flags & ZEND_ACC_PRIVATE) {
 		func->common.fn_flags &= ~ZEND_ACC_PPP_MASK;
@@ -465,8 +465,9 @@ static int php_runkit_method_copy(zend_string *dclass, zend_string* dfunc, zend_
 			php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 		}
 	}
+	/* Postcondition: Method does not already exist in dce's function table (Would return FAILURE if it did) */
 
-	dfe = php_runkit_function_clone(sfe, dfunc TSRMLS_CC);
+	dfe = php_runkit_function_clone(sfe, dfunc, ZEND_USER_FUNCTION TSRMLS_CC);
 
 	// TODO: Check if this is a memory leak.
 	if (zend_hash_add_ptr(&dce->function_table, dfunc_lower, dfe) == NULL) {
@@ -605,7 +606,8 @@ PHP_FUNCTION(runkit_method_rename)
 
 	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 
-	func = php_runkit_function_clone(fe, newname TSRMLS_CC);
+	/* TODO: Figure out how to find the original function type. */
+	func = php_runkit_function_clone(fe, newname, fe->type TSRMLS_CC);
 
 	if (zend_hash_add_ptr(&ce->function_table, newname_lower, func) == NULL) {
 		zend_string_release(newname_lower);

--- a/runkit_zend_execute_API.c
+++ b/runkit_zend_execute_API.c
@@ -1,0 +1,285 @@
+#include "php_runkit_zend_execute_API.h"
+
+#include "Zend/zend_API.h"
+#include "Zend/zend_compile.h"
+#include "Zend/zend_exceptions.h"
+#include "Zend/zend_generators.h"
+#include "Zend/zend_globals_macros.h"
+#include "Zend/zend_types.h"
+
+/**
+ * Copies of internal methods from Zend/zend_execute_API.c
+ * These are used to call internal methods (not in the function table) from the external method.
+ * TODO: See if xdebug works
+ */
+int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inner, INTERNAL_FUNCTION_PARAMETERS) /* {{{ */
+{
+	uint32_t i;
+	zend_class_entry *calling_scope = NULL;
+	zend_execute_data *call, dummy_execute_data;
+	zend_fcall_info_cache fci_cache_local = {0};
+	zend_function *func;
+	zend_class_entry *orig_scope;
+	/* {{{ patch for runkit */
+	zend_fcall_info fci = {0};
+	zend_fcall_info_cache *fci_cache = NULL;
+
+	fci.size = sizeof(fci);
+	fci.function_table = EG(function_table);
+	fci.object = NULL; // FIXME for methods? // object ? Z_OBJ_P(object) : NULL;
+	ZVAL_STR(&fci.function_name, fbc_inner->common.function_name);
+	zend_string_addref(fbc_inner->common.function_name);
+	fci.retval = return_value;
+	fci.param_count = ZEND_CALL_NUM_ARGS(EG(current_execute_data));
+	fci.params = ZEND_CALL_ARG(EG(current_execute_data), 1);  // params and param_count From zend_API.c
+	fci.no_separation = (zend_bool) 1;  // ???
+	fci.symbol_table = NULL; // ???
+	/* end patch for runkit }}} */
+
+	ZVAL_UNDEF(fci.retval);
+
+	if (!EG(active)) {
+		return FAILURE; /* executor is already inactive */
+	}
+
+	if (EG(exception)) {
+		return FAILURE; /* we would result in an instable executor otherwise */
+	}
+
+	switch (fci.size) {
+		case sizeof(zend_fcall_info):
+			break; /* nothing to do currently */
+		default:
+			zend_error_noreturn(E_CORE_ERROR, "Corrupted fcall_info provided to zend_call_function()");
+			break;
+	}
+
+	orig_scope = EG(scope);
+
+	/* Initialize execute_data */
+	if (!EG(current_execute_data)) {
+		/* This only happens when we're called outside any execute()'s
+		 * It shouldn't be strictly necessary to NULL execute_data out,
+		 * but it may make bugs easier to spot
+		 */
+		memset(&dummy_execute_data, 0, sizeof(zend_execute_data));
+		EG(current_execute_data) = &dummy_execute_data;
+	} else if (EG(current_execute_data)->func &&
+	           ZEND_USER_CODE(EG(current_execute_data)->func->common.type) &&
+	           EG(current_execute_data)->opline->opcode != ZEND_DO_FCALL &&
+	           EG(current_execute_data)->opline->opcode != ZEND_DO_ICALL &&
+	           EG(current_execute_data)->opline->opcode != ZEND_DO_UCALL &&
+	           EG(current_execute_data)->opline->opcode != ZEND_DO_FCALL_BY_NAME) {
+		/* Insert fake frame in case of include or magic calls */
+		dummy_execute_data = *EG(current_execute_data);
+		dummy_execute_data.prev_execute_data = EG(current_execute_data);
+		dummy_execute_data.call = NULL;
+		dummy_execute_data.opline = NULL;
+		dummy_execute_data.func = NULL;
+		EG(current_execute_data) = &dummy_execute_data;
+	}
+
+	if (!fci_cache || !fci_cache->initialized) {
+		zend_string *callable_name;
+		char *error = NULL;
+
+		if (!fci_cache) {
+			fci_cache = &fci_cache_local;
+		}
+
+		if (!zend_is_callable_ex(&fci.function_name, fci.object, IS_CALLABLE_CHECK_SILENT, &callable_name, fci_cache, &error)) {
+			if (error) {
+				zend_error(E_WARNING, "Invalid callback %s, %s", ZSTR_VAL(callable_name), error);
+				efree(error);
+			}
+			if (callable_name) {
+				zend_string_release(callable_name);
+			}
+			if (EG(current_execute_data) == &dummy_execute_data) {
+				EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+			}
+			return FAILURE;
+		} else if (error) {
+			/* Capitalize the first latter of the error message */
+			if (error[0] >= 'a' && error[0] <= 'z') {
+				error[0] += ('A' - 'a');
+			}
+			zend_error(E_DEPRECATED, "%s", error);
+			efree(error);
+		}
+		zend_string_release(callable_name);
+	}
+
+	func = fbc_inner;
+	call = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION,
+		func, fci.param_count, fci_cache->called_scope, fci_cache->object);
+	calling_scope = fci_cache->calling_scope;
+	fci.object = fci_cache->object;
+	if (fci.object &&
+	    (!EG(objects_store).object_buckets ||
+	     !IS_OBJ_VALID(EG(objects_store).object_buckets[fci.object->handle]))) {
+		if (EG(current_execute_data) == &dummy_execute_data) {
+			EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+		}
+		return FAILURE;
+	}
+
+	if (func->common.fn_flags & (ZEND_ACC_ABSTRACT|ZEND_ACC_DEPRECATED)) {
+		if (func->common.fn_flags & ZEND_ACC_ABSTRACT) {
+			zend_throw_error(NULL, "Cannot call abstract method %s::%s()", ZSTR_VAL(func->common.scope->name), ZSTR_VAL(func->common.function_name));
+			if (EG(current_execute_data) == &dummy_execute_data) {
+				EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+			}
+			return FAILURE;
+		}
+		if (func->common.fn_flags & ZEND_ACC_DEPRECATED) {
+ 			zend_error(E_DEPRECATED, "Function %s%s%s() is deprecated",
+				func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
+				func->common.scope ? "::" : "",
+				ZSTR_VAL(func->common.function_name));
+		}
+	}
+
+	for (i=0; i<fci.param_count; i++) {
+		zval *param;
+		zval *arg = &fci.params[i];
+
+		if (ARG_SHOULD_BE_SENT_BY_REF(func, i + 1)) {
+			if (UNEXPECTED(!Z_ISREF_P(arg))) {
+				if (fci.no_separation &&
+					!ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
+					if (i) {
+						/* hack to clean up the stack */
+						ZEND_CALL_NUM_ARGS(call) = i;
+						zend_vm_stack_free_args(call);
+					}
+					zend_vm_stack_free_call_frame(call);
+
+					zend_error(E_WARNING, "Parameter %d to %s%s%s() expected to be a reference, value given",
+						i+1,
+						func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
+						func->common.scope ? "::" : "",
+						ZSTR_VAL(func->common.function_name));
+					if (EG(current_execute_data) == &dummy_execute_data) {
+						EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+					}
+					return FAILURE;
+				}
+
+				ZVAL_NEW_REF(arg, arg);
+			}
+			Z_ADDREF_P(arg);
+		} else {
+			if (Z_ISREF_P(arg) &&
+			    !(func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
+				/* don't separate references for __call */
+				arg = Z_REFVAL_P(arg);
+			}
+			if (Z_OPT_REFCOUNTED_P(arg)) {
+				Z_ADDREF_P(arg);
+			}
+		}
+		param = ZEND_CALL_ARG(call, i+1);
+		ZVAL_COPY_VALUE(param, arg);
+	}
+
+	EG(scope) = calling_scope;
+	if (func->common.fn_flags & ZEND_ACC_STATIC) {
+		fci.object = NULL;
+	}
+	Z_OBJ(call->This) = fci.object;
+
+	if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
+		ZEND_ASSERT(GC_TYPE((zend_object*)func->op_array.prototype) == IS_OBJECT);
+		GC_REFCOUNT((zend_object*)func->op_array.prototype)++;
+		ZEND_ADD_CALL_FLAG(call, ZEND_CALL_CLOSURE);
+	}
+
+	/* PHP-7 doesn't support symbol_table substitution for functions */
+	ZEND_ASSERT(fci.symbol_table == NULL);
+
+	if (func->type == ZEND_USER_FUNCTION) {
+		int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
+		EG(scope) = func->common.scope;
+		call->symbol_table = fci.symbol_table;
+		if (EXPECTED((func->op_array.fn_flags & ZEND_ACC_GENERATOR) == 0)) {
+			zend_init_execute_data(call, &func->op_array, fci.retval);
+			zend_execute_ex(call);
+		} else {
+			zend_generator_create_zval(call, &func->op_array, fci.retval);
+		}
+		if (call_via_handler) {
+			/* We must re-initialize function again */
+			fci_cache->initialized = 0;
+		}
+	} else if (func->type == ZEND_INTERNAL_FUNCTION) {
+		int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
+		ZVAL_NULL(fci.retval);
+		if (func->common.scope) {
+			EG(scope) = func->common.scope;
+		}
+		call->prev_execute_data = EG(current_execute_data);
+		call->return_value = NULL; /* this is not a constructor call */
+		EG(current_execute_data) = call;
+		if (EXPECTED(zend_execute_internal == NULL)) {
+			/* saves one function call if zend_execute_internal is not used */
+			func->internal_function.handler(call, fci.retval);
+		} else {
+			zend_execute_internal(call, fci.retval);
+		}
+		EG(current_execute_data) = call->prev_execute_data;
+		zend_vm_stack_free_args(call);
+
+		/*  We shouldn't fix bad extensions here,
+			because it can break proper ones (Bug #34045)
+		if (!EX(function_state).function->common.return_reference)
+		{
+			INIT_PZVAL(f->retval);
+		}*/
+		if (EG(exception)) {
+			zval_ptr_dtor(fci.retval);
+			ZVAL_UNDEF(fci.retval);
+		}
+
+		if (call_via_handler) {
+			/* We must re-initialize function again */
+			fci_cache->initialized = 0;
+		}
+	} else { /* ZEND_OVERLOADED_FUNCTION */
+		ZVAL_NULL(fci.retval);
+
+		/* Not sure what should be done here if it's a static method */
+		if (fci.object) {
+			call->prev_execute_data = EG(current_execute_data);
+			EG(current_execute_data) = call;
+			fci.object->handlers->call_method(func->common.function_name, fci.object, call, fci.retval);
+			EG(current_execute_data) = call->prev_execute_data;
+		} else {
+			zend_throw_error(NULL, "Cannot call overloaded function for non-object");
+		}
+
+		zend_vm_stack_free_args(call);
+
+		if (func->type == ZEND_OVERLOADED_FUNCTION_TEMPORARY) {
+			zend_string_release(func->common.function_name);
+		}
+		efree(func);
+
+		if (EG(exception)) {
+			zval_ptr_dtor(fci.retval);
+			ZVAL_UNDEF(fci.retval);
+		}
+	}
+
+	EG(scope) = orig_scope;
+	zend_vm_stack_free_call_frame(call);
+
+	if (EG(current_execute_data) == &dummy_execute_data) {
+		EG(current_execute_data) = dummy_execute_data.prev_execute_data;
+	}
+
+	if (EG(exception)) {
+		zend_throw_exception_internal(NULL);
+	}
+	return SUCCESS;
+}

--- a/runkit_zend_execute_API.c
+++ b/runkit_zend_execute_API.c
@@ -1,5 +1,6 @@
 #include "php_runkit_zend_execute_API.h"
 
+#include "main/php_version.h"
 #include "Zend/zend_API.h"
 #include "Zend/zend_compile.h"
 #include "Zend/zend_exceptions.h"
@@ -15,17 +16,23 @@
 int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inner, INTERNAL_FUNCTION_PARAMETERS) /* {{{ */
 {
 	uint32_t i;
+#if PHP_VERSION_ID < 70100
 	zend_class_entry *calling_scope = NULL;
+#endif
 	zend_execute_data *call, dummy_execute_data;
 	zend_fcall_info_cache fci_cache_local = {0};
 	zend_function *func;
+#if PHP_VERSION_ID < 70100
 	zend_class_entry *orig_scope;
+#endif
 	/* {{{ patch for runkit */
 	zend_fcall_info fci = {0};
 	zend_fcall_info_cache *fci_cache = NULL;
 
 	fci.size = sizeof(fci);
+#if PHP_VERSION_ID < 70100
 	fci.function_table = EG(function_table);
+#endif
 	fci.object = NULL; // FIXME for methods? // object ? Z_OBJ_P(object) : NULL;
 	ZVAL_STR(&fci.function_name, fbc_inner->common.function_name);
 	zend_string_addref(fbc_inner->common.function_name);
@@ -33,7 +40,9 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 	fci.param_count = ZEND_CALL_NUM_ARGS(EG(current_execute_data));
 	fci.params = ZEND_CALL_ARG(EG(current_execute_data), 1);  // params and param_count From zend_API.c
 	fci.no_separation = (zend_bool) 1;  // ???
+#if PHP_VERSION_ID < 70100
 	fci.symbol_table = NULL; // ???
+#endif
 	/* end patch for runkit }}} */
 
 	ZVAL_UNDEF(fci.retval);
@@ -46,15 +55,9 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 		return FAILURE; /* we would result in an instable executor otherwise */
 	}
 
-	switch (fci.size) {
-		case sizeof(zend_fcall_info):
-			break; /* nothing to do currently */
-		default:
-			zend_error_noreturn(E_CORE_ERROR, "Corrupted fcall_info provided to zend_call_function()");
-			break;
-	}
-
+#if PHP_VERSION_ID < 70100
 	orig_scope = EG(scope);
+#endif
 
 	/* Initialize execute_data */
 	if (!EG(current_execute_data)) {
@@ -111,10 +114,18 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 	}
 
 	func = fbc_inner;
+#if PHP_VERSION_ID < 70100
 	call = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION,
 		func, fci.param_count, fci_cache->called_scope, fci_cache->object);
 	calling_scope = fci_cache->calling_scope;
 	fci.object = fci_cache->object;
+#else
+    fci.object = (func->common.fn_flags & ZEND_ACC_STATIC) ?
+	   NULL : fci_cache->object;
+
+    call = zend_vm_stack_push_call_frame(ZEND_CALL_TOP_FUNCTION | ZEND_CALL_DYNAMIC,
+	   func, fci.param_count, fci_cache->called_scope, fci.object);
+#endif
 	if (fci.object &&
 	    (!EG(objects_store).object_buckets ||
 	     !IS_OBJ_VALID(EG(objects_store).object_buckets[fci.object->handle]))) {
@@ -145,6 +156,7 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 		zval *arg = &fci.params[i];
 
 		if (ARG_SHOULD_BE_SENT_BY_REF(func, i + 1)) {
+#if PHP_VERSION_ID < 70100
 			if (UNEXPECTED(!Z_ISREF_P(arg))) {
 				if (fci.no_separation &&
 					!ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
@@ -169,25 +181,49 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 				ZVAL_NEW_REF(arg, arg);
 			}
 			Z_ADDREF_P(arg);
+#else
+			if (UNEXPECTED(!Z_ISREF_P(arg))) {
+				if (!fci.no_separation) {
+					/* Separation is enabled -- create a ref */
+					ZVAL_NEW_REF(arg, arg);
+				} else if (!ARG_MAY_BE_SENT_BY_REF(func, i + 1)) {
+					/* By-value send is not allowed -- emit a warning,
+					 * but still perform the call with a by-value send. */
+					zend_error(E_WARNING,
+						"Parameter %d to %s%s%s() expected to be a reference, value given", i+1,
+						func->common.scope ? ZSTR_VAL(func->common.scope->name) : "",
+						func->common.scope ? "::" : "",
+						ZSTR_VAL(func->common.function_name));
+				}
+			}
+#endif
 		} else {
 			if (Z_ISREF_P(arg) &&
 			    !(func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE)) {
 				/* don't separate references for __call */
 				arg = Z_REFVAL_P(arg);
 			}
+#if PHP_VERSION_ID < 70100
 			if (Z_OPT_REFCOUNTED_P(arg)) {
 				Z_ADDREF_P(arg);
 			}
+#endif
 		}
 		param = ZEND_CALL_ARG(call, i+1);
+#if PHP_VERSION_ID < 70100
 		ZVAL_COPY_VALUE(param, arg);
+#else 
+		ZVAL_COPY(param, arg);
+#endif
 	}
 
+#if PHP_VERSION_ID < 70100
 	EG(scope) = calling_scope;
 	if (func->common.fn_flags & ZEND_ACC_STATIC) {
 		fci.object = NULL;
 	}
 	Z_OBJ(call->This) = fci.object;
+#endif
 
 	if (UNEXPECTED(func->op_array.fn_flags & ZEND_ACC_CLOSURE)) {
 		ZEND_ASSERT(GC_TYPE((zend_object*)func->op_array.prototype) == IS_OBJECT);
@@ -195,11 +231,14 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 		ZEND_ADD_CALL_FLAG(call, ZEND_CALL_CLOSURE);
 	}
 
-	/* PHP-7 doesn't support symbol_table substitution for functions */
+#if PHP_VERSION_ID < 70100
+	/* PHP-7 doesn't support symbol_table substitution for functions. Removed in 7.1.0 */
 	ZEND_ASSERT(fci.symbol_table == NULL);
+#endif
 
 	if (func->type == ZEND_USER_FUNCTION) {
 		int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
+#if PHP_VERSION_ID < 70100
 		EG(scope) = func->common.scope;
 		call->symbol_table = fci.symbol_table;
 		if (EXPECTED((func->op_array.fn_flags & ZEND_ACC_GENERATOR) == 0)) {
@@ -208,6 +247,10 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 		} else {
 			zend_generator_create_zval(call, &func->op_array, fci.retval);
 		}
+#else
+		zend_init_execute_data(call, &func->op_array, fci.retval);
+		zend_execute_ex(call);
+#endif
 		if (call_via_handler) {
 			/* We must re-initialize function again */
 			fci_cache->initialized = 0;
@@ -215,9 +258,11 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 	} else if (func->type == ZEND_INTERNAL_FUNCTION) {
 		int call_via_handler = (func->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) != 0;
 		ZVAL_NULL(fci.retval);
+#if PHP_VERSION_ID < 70100
 		if (func->common.scope) {
 			EG(scope) = func->common.scope;
 		}
+#endif
 		call->prev_execute_data = EG(current_execute_data);
 		call->return_value = NULL; /* this is not a constructor call */
 		EG(current_execute_data) = call;
@@ -271,7 +316,9 @@ int runkit_forward_call_user_function(zend_function *fbc, zend_function *fbc_inn
 		}
 	}
 
+#if PHP_VERSION_ID < 70100
 	EG(scope) = orig_scope;
+#endif
 	zend_vm_stack_free_call_frame(call);
 
 	if (EG(current_execute_data) == &dummy_execute_data) {

--- a/tests/runkit_method_add_closure.phpt
+++ b/tests/runkit_method_add_closure.phpt
@@ -32,7 +32,13 @@ class test {
 			echo "g $is $g\n";
 			$d .= ' modified';
 			echo '$this is ';
-			var_dump($this);
+			try {
+				var_dump($this);
+			} catch(Error $e) {
+				// PHP 7.1 would also throw an Error if this was the actual implementation of runkit_method.
+				printf("\nError: %s\n", $e->getMessage());
+				printf("NULL\n");
+			}
 		});
 		runkit_class::runkit_method('foo', 'bar');
 		echo "d after call is $d\n";
@@ -44,14 +50,14 @@ $t->run();
 $rc = new runkit_class();
 $rc->runkit_method('foo','bar');
 ?>
---EXPECTF--
+--EXPECTREGEX--
 a is foo
 b is bar
 c is use
 d is ref_use
 g is global
-$this is 
-Notice: Undefined variable: this in %s on line %d
+\$this is 
+(Notice: Undefined variable: this in .* on line [0-9]+|Error: Using \$this when not in object context)
 NULL
 d after call is ref_use modified
 a is foo
@@ -59,5 +65,5 @@ b is bar
 c is use
 d is ref_use modified
 g is global
-$this is object(runkit_class)#2 (0) {
+\$this is object\(runkit_class\)#2 \(0\) {
 }


### PR DESCRIPTION
internal_override=1 is still not working completely properly
The Zend VM handles internal and external functions differently as of php 7.1 and up. This means more work is needed in redefining, tracking, and making sure that functions are callable. 
(This PR allows users to redefine an internal function to a user function and call it, but not to redefine a user function to an internal function and call it. 
redefining internal functions to a temporary function and back works, with some memory leaks.)

Work on a test of redefining a function value.

Before, they were treated uniformly.

- On top of that, there are probabably multiple possible VM implementations,
  if I remember correctly. Macros control which one is used by
  php_runkit_zend_execute.h?
  The solution should work with all VM implementations, including XDebug
- Copy the functions from runkit_zend_API.h
- Work on fixing internal functions redefined as user functions.
  This is not done yet... One can't call `sprintf` as `sprintf_original()` yet.
- WIP - Able to call user function from internal function, not all edge
  cases may be handled yet.
- update package.xml
- There are still some memory leaks on shutdown.