### PR TITLE
Implement support for return types in runkit_*_add/redefine

### DIFF
--- a/tests/runkit_function_add_return_type.phpt
+++ b/tests/runkit_function_add_return_type.phpt
@@ -1,0 +1,21 @@
+--TEST--
+runkit_function_add() function should accept valid return types passed in as a string
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php declare(strict_types=1);
+ini_set('error_reporting', (string)(E_ALL));
+
+runkit_function_add('runkit_function', 'string $a, $valid=false', 'return $valid ? $a : new stdClass();', false, '/** doc comment */', 'string');
+printf("Returned %s\n", runkit_function('foo', true));
+try {
+	printf("Returned %s\n", runkit_function('notastring', false));
+} catch (TypeError $e) {
+	printf("TypeError: %s", $e->getMessage());
+}
+?>
+--EXPECT--
+Returned foo
+TypeError: Return value of runkit_function() must be of the type string, object returned

--- a/tests/runkit_function_add_return_type_invalid.phpt
+++ b/tests/runkit_function_add_return_type_invalid.phpt
@@ -1,0 +1,18 @@
+--TEST--
+runkit_function_add() function should detect invalid return types passed in as a string
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php declare(strict_types=1);
+ini_set('error_reporting', (string)(E_ALL));
+
+$retval = runkit_function_add('runkit_function', 'string $a, $valid=false', 'return $valid ? $a : new stdClass();', false, '/** doc comment */', 'string#');
+printf("runkit_function_add returned: %s\n", var_export($retval, true));
+printf("Function exists: %s\n", var_export(function_exists('runkit_function'), true));
+?>
+--EXPECTF--
+Warning: runkit_function_add(): Return type should match regex %s in %s on line %d
+runkit_function_add returned: false
+Function exists: false

--- a/tests/runkit_method_add_return_type.phpt
+++ b/tests/runkit_method_add_return_type.phpt
@@ -1,0 +1,24 @@
+--TEST--
+runkit_method_add() function should accept valid return types passed in as a string
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php declare(strict_types=1);
+ini_set('error_reporting', (string)(E_ALL));
+
+class runkit_class {
+}
+
+runkit_method_add('runkit_class', 'runkit_method', 'string $a, $valid=false', 'return $valid ? $a : new stdClass();', RUNKIT_ACC_STATIC, '/** doc comment */', 'string');
+printf("Returned %s\n", runkit_class::runkit_method('foo', true));
+try {
+	printf("Returned %s\n", runkit_class::runkit_method('notastring', false));
+} catch (TypeError $e) {
+	printf("TypeError: %s", $e->getMessage());
+}
+?>
+--EXPECT--
+Returned foo
+TypeError: Return value of runkit_class::runkit_method() must be of the type string, object returned

--- a/tests/runkit_method_add_return_type_invalid.phpt
+++ b/tests/runkit_method_add_return_type_invalid.phpt
@@ -1,0 +1,18 @@
+--TEST--
+runkit_method_add() function should detect invalid return types passed in as a string
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php declare(strict_types=1);
+ini_set('error_reporting', (string)(E_ALL));
+
+$retval = runkit_method_add('runkit_class', 'runkit_method', 'string $a, $valid=false', 'return $valid ? $a : new stdClass();', RUNKIT_ACC_STATIC, '/** doc comment */', 'string#');
+printf("runkit_method_add returned: %s\n", var_export($retval, true));
+printf("Method exists: %s\n", var_export(method_exists('runkit_class', 'runkit_method'), true));
+?>
+--EXPECTF--
+Warning: runkit_method_add(): Return type should match regex %s in %s on line %d
+runkit_method_add returned: false
+Method exists: false


### PR DESCRIPTION
Add a simple sanity check that the identifier is valid.
In php 7.1, the return types can be made nullable by adding a preceding "?"
The empty string is treated the same way as passing null (No return
type)

For issue #4 