### PR TITLE
Disable xdebug in travis when running tests of runkit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_script:
  - (export CC; phpize && ./configure && make)
 
 script:
+ - phpenv config-rm xdebug.ini || true
  - ci/run_tests.sh
 
 notifications:


### PR DESCRIPTION
xdebug runs when fpm tests are run in travis, and that modifies the error output.