### PR TITLE
Fixes issue #49: Allow creating array constants via runkit_constant_add

### DIFF
--- a/tests/runkit_constant_add_array.phpt
+++ b/tests/runkit_constant_add_array.phpt
@@ -1,0 +1,22 @@
+--TEST--
+runkit_constant_add() function can add simple arrays
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--FILE--
+<?php
+runkit_constant_add('FOO', ["BAR"]);
+var_export(FOO);
+echo "\n";
+runkit_constant_redefine('FOO', [['key' => "BAR"]]);
+var_export(FOO);
+?>
+--EXPECT--
+array (
+  0 => 'BAR',
+)
+array (
+  0 => 
+  array (
+    'key' => 'BAR',
+  ),
+)

--- a/tests/runkit_constant_add_array_to_class.phpt
+++ b/tests/runkit_constant_add_array_to_class.phpt
@@ -1,0 +1,23 @@
+--TEST--
+runkit_constant_add() function can add simple arrays to classes
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--FILE--
+<?php
+class A { }
+runkit_constant_add('A::FOO', ["BAR"]);
+var_export(A::FOO);
+echo "\n";
+runkit_constant_redefine('A::FOO', [['key' => "BAR"]]);
+var_export(A::FOO);
+?>
+--EXPECT--
+array (
+  0 => 'BAR',
+)
+array (
+  0 => 
+  array (
+    'key' => 'BAR',
+  ),
+)

--- a/tests/runkit_constant_redefine_protected_across_file.phpt
+++ b/tests/runkit_constant_redefine_protected_across_file.phpt
@@ -18,15 +18,28 @@ class TestClass extends TestBaseClass{
 
 $const = 'TestBaseClass::_FOO';
 var_dump($const, TestClass::get_foo());
-runkit_constant_redefine($const, 'bar');
+runkit_constant_redefine($const, 'roh');
 var_dump($const, TestClass::get_foo());
-runkit_constant_redefine($const, 'foo');
-var_dump(TestClass::get_foo());
+$x = TestClass::get_foo();
+runkit_constant_redefine($const, $x);
+var_dump($const, TestClass::get_foo());
+runkit_constant_redefine($const, ['dah']);
+var_dump($const, TestClass::get_foo());
+runkit_constant_redefine($const, 2);
+var_dump($const, TestClass::get_foo());
 // TODO test subclass
 ?>
 --EXPECT--
 string(19) "TestBaseClass::_FOO"
 string(3) "foo"
 string(19) "TestBaseClass::_FOO"
-string(3) "bar"
-string(3) "foo"
+string(3) "roh"
+string(19) "TestBaseClass::_FOO"
+string(3) "roh"
+string(19) "TestBaseClass::_FOO"
+array(1) {
+  [0]=>
+  string(3) "dah"
+}
+string(19) "TestBaseClass::_FOO"
+int(2)


### PR DESCRIPTION
In both global constants and class constants
Also fix a memory leak and corrupted data when redefining string constants
multiple times.

Add test cases. Debug issues adding constants.

TODO: Finish supporting defining constants as resources.