### PR TITLE
Fixes issue #1: Allow `self`, `parent` in defined methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ __Now with partial support for PHP7.0 and PHP7.1!__ (This extension isn't produc
 Current Build Status
 --------------------
 
-In 7.0.x: Roughly 12 failing tests, 93 skipped tests, 79 passing tests.
-
-In 7.1.x: More segmentation faults and test failures than 7.0.x
+In 7.0.x and 7.1.x: Roughly 4 failing tests, 93 skipped tests, 91 passing tests.
 
 Compatability: PHP7.0 (Partial, buggy)
 --------------------------------------

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -221,8 +221,11 @@ void php_runkit_function_dtor(zend_function *fe);
 int php_runkit_remove_from_function_table(HashTable *function_table, zend_string *func_lower);
 void* php_runkit_update_function_table(HashTable *function_table, zend_string *func_lower, zend_function *f);
 int php_runkit_generate_lambda_method(const zend_string *arguments, const zend_string *return_type, const zend_string *phpcode,
+                                      zend_function **pfe, zend_bool return_ref, zend_bool is_static TSRMLS_DC);
+int php_runkit_generate_lambda_function(const zend_string *arguments, const zend_string *return_type, const zend_string *phpcode,
                                       zend_function **pfe, zend_bool return_ref TSRMLS_DC);
 int php_runkit_cleanup_lambda_method();
+int php_runkit_cleanup_lambda_function();
 int php_runkit_destroy_misplaced_functions(zval *pDest TSRMLS_DC);
 void php_runkit_restore_internal_function(zend_string *fname_lower, zend_function *f);
 

--- a/runkit_methods.c
+++ b/runkit_methods.c
@@ -375,7 +375,8 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 
 	if (!source_fe) {
 		if (php_runkit_generate_lambda_method(arguments, return_type.return_type, phpcode, &source_fe,
-						     (flags & PHP_RUNKIT_ACC_RETURN_REFERENCE) == PHP_RUNKIT_ACC_RETURN_REFERENCE
+						     (flags & PHP_RUNKIT_ACC_RETURN_REFERENCE) == PHP_RUNKIT_ACC_RETURN_REFERENCE,
+							 ((flags & ZEND_ACC_STATIC) != 0)
 						     TSRMLS_CC) == FAILURE) {
 			zend_string_release(methodname_lower);
 			RETURN_FALSE;

--- a/tests/bug56662.phpt
+++ b/tests/bug56662.phpt
@@ -16,7 +16,7 @@ Reflection::export(new ReflectionMethod('C', 'x'));
 
 --EXPECTF--
 Method [ <user%S> public method x ] {
-  @@ %sbug56662.php(3) : runkit runtime-created function 1 - 1
+  @@ %sbug56662.php(3) : runkit runtime-created method 1 - 1
 }
 
 Method [ <user, overwrites A%S> public method x ] {


### PR DESCRIPTION
Previously, this wouldn't work because it would evaluate a global
function (Not a method).
After this change, runkit_method_add/redefine will create a temporary class, and create a
method inside that class.
Then, copy the method implementation to the desired place and discard
the temporary class.