### PR TITLE
Fix fpm build failure, 7.1.0 build failure

### DIFF
--- a/php_runkit.h
+++ b/php_runkit.h
@@ -151,6 +151,7 @@ ZEND_BEGIN_MODULE_GLOBALS(runkit)
 	zend_bool internal_override;
 	const char *name_str, *removed_method_str, *removed_function_str, *removed_parameter_str;
 	zend_function *removed_function, *removed_method;
+	zend_bool module_moved_to_front;
 #endif
 ZEND_END_MODULE_GLOBALS(runkit)
 #endif

--- a/php_runkit_hash.h
+++ b/php_runkit_hash.h
@@ -22,15 +22,23 @@
 #ifndef PHP_RUNKIT_HASH_H
 #define PHP_RUNKIT_HASH_H
 
+#ifdef PHP_RUNKIT_MANIPULATION
+
+#include "php_runkit.h"
+#include "Zend/zend_types.h"
+#include "Zend/zend_types.h"
+
 /* {{{ php_runkit_hash_get_bucket */
 // Copied from zend_hash_find_bucket of zend_hash.c and modified slightly.
-inline static Bucket *php_runkit_hash_get_bucket(HashTable *ht, zend_string* key) {
+// Same as the implementation in 7.0 and 7.1
+inline static Bucket *php_runkit_zend_hash_find_bucket(HashTable *ht, zend_string* key)
+{
+	zend_ulong h;
 	uint32_t nIndex;
 	uint32_t idx;
-  uint32_t h;
 	Bucket *p, *arData;
 
-  h = ZSTR_HASH(key);
+	h = zend_string_hash_val(key);
 	arData = ht->arData;
 	nIndex = h | ht->nTableMask;
 	idx = HT_HASH_EX(arData, nIndex);
@@ -39,9 +47,9 @@ inline static Bucket *php_runkit_hash_get_bucket(HashTable *ht, zend_string* key
 		if (EXPECTED(p->key == key)) { /* check for the same interned string */
 			return p;
 		} else if (EXPECTED(p->h == h) &&
-		     EXPECTED(p->key) &&
-		     EXPECTED(ZSTR_LEN(p->key) == ZSTR_LEN(key)) &&
-		     EXPECTED(memcmp(ZSTR_VAL(p->key), ZSTR_VAL(key), ZSTR_LEN(key)) == 0)) {
+				EXPECTED(p->key) &&
+				EXPECTED(ZSTR_LEN(p->key) == ZSTR_LEN(key)) &&
+				EXPECTED(memcmp(ZSTR_VAL(p->key), ZSTR_VAL(key), ZSTR_LEN(key)) == 0)) {
 			return p;
 		}
 		idx = Z_NEXT(p->val);
@@ -50,16 +58,89 @@ inline static Bucket *php_runkit_hash_get_bucket(HashTable *ht, zend_string* key
 }
 /* }}} */
 
-/* {{{ php_runkit_hash_move_to_front */
-inline static void php_runkit_hash_move_to_front(HashTable *ht, Bucket *p) {
-	if (!p) return;
+/* {{{ php_runkit_hash_move_runkit_to_front }}} */
+// Moves the runkit module to the front of the list (After "core", but before modules such as "session"
+// so that it will be unloaded after all of the PHP code is executed.
+inline static void php_runkit_hash_move_runkit_to_front() {
+	zend_ulong numkey;
+	zend_string *strkey;
+	zend_string *runkit_str;
+	dtor_func_t oldPDestructor;
+	zend_module_entry *module;
+	int num = 0;
+	HashTable tmp;
+	if (RUNKIT_G(module_moved_to_front)) {
+		// Already moved it to the front (but after "core").
+		return;
+	}
+	RUNKIT_G(module_moved_to_front) = 1;
 
-  // TODO: It appears that HT_HASH is the index of the next element in the chained list (negative index)
-  // and Z_NEXT will point to the old value for this element.
+	runkit_str = zend_string_init("runkit", sizeof("runkit") - 1, 0);
+	// 1. If runkit is not part of the module registry, warn and do nothing.
+	if (!zend_hash_exists(&module_registry, runkit_str)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to find \"runkit\" module when attempting to change module unloading order - The lifetime of internal function overrides will be unexpected");
+		zend_string_release(runkit_str);
+		return;
+	}
+	// php_error_docref(NULL TSRMLS_CC, E_WARNING, "In php_runkit_hash_move_to_front size=%d", (int)zend_hash_num_elements(&module_registry));
 
-  // TODO: Actually implement move-to-front, even if it isn't efficient (E.g. repeatedly insert)
-  return;
+	// 2. Create a temporary table with "runkit" at the front.
+	ZEND_HASH_FOREACH_KEY_PTR(&module_registry, numkey, strkey, module) {
+		// php_error_docref(NULL TSRMLS_CC, E_WARNING, "In php_runkit_hash_move_to_front numkey=%d strkey=%s refcount=%d zv=%llx", (int)numkey, strkey != NULL ? ZSTR_VAL(strkey) : "null", (int)(strkey != NULL ? zend_string_refcount(strkey) : 0), (long long) (uintptr_t)module);
+		if (num++ == 0) {
+			zend_bool first_is_core = 0;
+			Bucket *b;
+			zend_hash_init(&tmp, zend_hash_num_elements(&module_registry), NULL, NULL, 0);
+			// add "core" first, then "runkit", then the remaining modules.
+			// If core isn't first, core tries to free the memory of strings that runkit allocated.
+			first_is_core = strkey != NULL && zend_string_equals_literal(strkey, "core");
+			if (first_is_core) {
+				zend_hash_add_ptr(&tmp, strkey, module);
+			} else {
+				php_error_docref(NULL TSRMLS_CC, E_WARNING, "unexpected module order: \"core\" isn't first");
+			}
+			// Otherwise, initialize the temporary table (with no destructor function)
+			b = php_runkit_zend_hash_find_bucket(&module_registry, runkit_str);
+
+			zend_hash_add_ptr(&tmp, b->key, Z_PTR(b->val));
+			if (first_is_core) {
+				continue;  // Already added "core" to tmp map
+			}
+		}
+		if (strkey != NULL) {
+			if (zend_string_equals(runkit_str, strkey)) {
+				// Already added persistent string for "runkit" to the front.
+				continue;
+			}
+			zend_hash_add_ptr(&tmp, strkey, module);
+		} else {
+			zend_hash_index_add_ptr(&tmp, numkey, module);
+		}
+	} ZEND_HASH_FOREACH_END();
+	zend_string_release(runkit_str);
+	runkit_str = NULL;
+
+	oldPDestructor = module_registry.pDestructor;
+	module_registry.pDestructor = NULL;
+	zend_hash_clean(&module_registry);
+	module_registry.pDestructor = oldPDestructor;
+	oldPDestructor = NULL;
+
+	// 3. Copy the reordered table to the original module_registry
+	ZEND_HASH_FOREACH_KEY_PTR(&tmp, numkey, strkey, module) {
+		if (strkey != NULL) {
+			zend_hash_add_ptr(&module_registry, strkey, module);
+		} else {
+			zend_hash_index_add_ptr(&module_registry, numkey, module);
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	tmp.pDestructor = NULL;
+	zend_hash_destroy(&tmp);
+
+	return;
 }
-/* }}} */
+
+#endif /* PHP_RUNKIT_MANIPULATION */
 
 #endif

--- a/tests/runkit_fpm_internal_function_restore.phpt
+++ b/tests/runkit_fpm_internal_function_restore.phpt
@@ -4,7 +4,6 @@ Test restoring internal functions after renaming and copying under fpm
 <?php include "_fpm_skipif.inc"; ?>
 --FILE--
 <?php
-// TODO: This isn't restoring properly, in 7.1RC3
 include "_fpm_include.inc";
 $code = <<<EOT
 <?php
@@ -21,22 +20,24 @@ fpm_test(array($code, $code, $code), "-d extension_dir=modules/ -d extension=run
 ?>
 Done
 --EXPECTF--
-true
 [%s] NOTICE: fpm is running, pid %d
 [%s] NOTICE: ready to handle connections
 Test Start
+true
 A B
 C D
 Test End
 
 Request ok
 Test Start
+true
 A B
 C D
 Test End
 
 Request ok
 Test Start
+true
 A B
 C D
 Test End

--- a/tests/runkit_function_redefine_closure_static.phpt
+++ b/tests/runkit_function_redefine_closure_static.phpt
@@ -3,7 +3,6 @@ runkit_method_redefine() function with closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '7.1.0', '>=')) print "skip";
 ?>
 --INI--
 display_errors=on
@@ -13,7 +12,7 @@ display_errors=on
 function runkit_function() {}
 
 class test {
-	public function run() {
+	public static function run() {
 		$c = 'use';
 		$d = 'ref_use';
 		runkit_function_redefine('runkit_function',
@@ -24,8 +23,6 @@ class test {
 				echo "c $is $c\nd $is $d\n";
 				echo "g $is $g\n";
 				$d .= ' modified';
-				echo '$this is';
-				var_dump($this);
 			}
 		);
 		runkit_function('foo', 'bar');
@@ -33,8 +30,7 @@ class test {
 	}
 }
 $g = 'global';
-$t = new test();
-$t->run();
+test::run();
 runkit_function('foo','bar');
 ?>
 --EXPECTF--
@@ -43,15 +39,9 @@ b is bar
 c is use
 d is ref_use
 g is global
-$this is
-Notice: Undefined variable: this in %s on line %d
-NULL
 d after call is ref_use modified
 a is foo
 b is bar
 c is use
 d is ref_use modified
 g is global
-$this is
-Notice: Undefined variable: this in %s on line %d
-NULL


### PR DESCRIPTION
The internal functions were being corrupted before they were being
restored. Simply accessing the memory (f->type) no longer worked

- Made sure that runkit was unloaded second last (after "core").
- Don't bother restoring functions if the function table is going to be
  destroyed instead of reused - Base this on SAPI
- Reuse existing persistent strings, so that we know they won't be
  garbage collected when php is running as `php-fpm`

Fix move_to_front - Unload runkit after the rest of the modules(probably unrelated)

- This is important for php-fpm and other modules, where the
  function table entries from the previous run are reused.
- This is also important so that runkit function overrides are present
  when other modules shut down for the request (e.g. session saving)

The behavior of `$this` has changed in a function constant. Change
runkit_function test with closure to reflect the expected 7.1 behavior
(`$this` would emit a warning when attempting to use that variable
in a global function implementation)

Fixes #59
Fixes #16