### PR TITLE
Remove version check for php<7 from tests

### DIFF
--- a/tests/bug10053.phpt
+++ b/tests/bug10053.phpt
@@ -3,7 +3,6 @@ runkit_method_copy() function
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/namespaces.phpt
+++ b/tests/namespaces.phpt
@@ -3,7 +3,6 @@ runkit_method_add(), runkit_method_redefine(), runkit_method_rename() & runkit_m
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_add_magic_methods.phpt
+++ b/tests/runkit_add_magic_methods.phpt
@@ -2,7 +2,6 @@
 adding and removing magic methods
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php
@@ -57,38 +56,20 @@ $uc = unserialize($s3);
 $ca = clone $a;
 $cb = clone $b;
 $cc = clone $c;
-if(version_compare(PHP_VERSION, '5.2.999', '>')) {
-	Test::method();
-	FOO_Test::method();
-	FOO_Test_child::method();
-} else {
-	echo "__callstatic\n";
-	echo "__callstatic\n";
-	echo "__callstatic\n";
-}
+Test::method();
+FOO_Test::method();
+FOO_Test_child::method();
 
-if(version_compare(PHP_VERSION, '5.1.999', '>')) {
-	echo $a;
-	echo $b;
-	echo $c;
-} else {
-	echo "__tostring\n";
-	echo "__tostring\n";
-	echo "__tostring\n";
-}
+echo $a;
+echo $b;
+echo $c;
 
-if(version_compare(PHP_VERSION, '5.5.999', '>')) {
-	var_dump($a);
-	ob_end_clean();
-	var_dump($b);
-	ob_end_clean();
-	var_dump($c);
-	ob_end_clean();
-} else {
-	echo "__debuginfo\n";
-	echo "__debuginfo\n";
-	echo "__debuginfo\n";
-}
+var_dump($a);
+ob_end_clean();
+var_dump($b);
+ob_end_clean();
+var_dump($c);
+ob_end_clean();
 $a = NULL;
 $b = NULL;
 $c = NULL;

--- a/tests/runkit_add_magic_serialize_method_ignored_for_common_classes.phpt
+++ b/tests/runkit_add_magic_serialize_method_ignored_for_common_classes.phpt
@@ -2,7 +2,6 @@
 adding magic serialize method to common class should be ignored
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_add_to_class.phpt
+++ b/tests/runkit_constant_add_to_class.phpt
@@ -3,7 +3,6 @@ runkit_constant_add() function redefines class constants
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_redefine_in_class.phpt
+++ b/tests/runkit_constant_redefine_in_class.phpt
@@ -3,7 +3,6 @@ runkit_constant_redefine() function redefines class constants
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_remove_from_class.phpt
+++ b/tests/runkit_constant_remove_from_class.phpt
@@ -3,7 +3,6 @@ runkit_constant_remove() function removes constant from class
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_remove_from_class_without_inlining.phpt
+++ b/tests/runkit_constant_remove_from_class_without_inlining.phpt
@@ -5,11 +5,10 @@ x=1
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php
-// If the compiler knows what TestClass will be, it would be able to 
+// If the compiler knows what TestClass will be, it would be able to
 // optimize out the opcode FETCH_CONSTANT and replace it with SEND_VAL 'foo'
 if ($_POST['x'] == 1) {
 	class TestClass {

--- a/tests/runkit_constant_remove_from_ns.phpt
+++ b/tests/runkit_constant_remove_from_ns.phpt
@@ -3,7 +3,6 @@ runkit_constant_remove(), runkit_constant_add(), and namespaces
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constants_manipulations_and_cache.phpt
+++ b/tests/runkit_constants_manipulations_and_cache.phpt
@@ -3,7 +3,6 @@ Test for caching issues on manipulations with constants
 --SKIPIF--
 <?php
   if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-  if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_default_property_add.phpt
+++ b/tests/runkit_default_property_add.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() function
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties.phpt
+++ b/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() and runkit_default_property_remove() functions on classes having dynamic properties
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties_overriding_in_objects.phpt
+++ b/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties_overriding_in_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() and runkit_default_property_remove() functions on classes having dynamic properties overriding in objects
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_add_instance.phpt
+++ b/tests/runkit_default_property_add_instance.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() function - instance override
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_overriding_objects.phpt
+++ b/tests/runkit_default_property_add_overriding_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() function with overriding objects
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_to_subclasses.phpt
+++ b/tests/runkit_default_property_add_to_subclasses.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() add properties to subclasses
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_to_subclasses_overriding_objects.phpt
+++ b/tests/runkit_default_property_add_to_subclasses_overriding_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() add properties to subclasses overriding objects
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove.phpt
+++ b/tests/runkit_default_property_remove.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() function
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties.phpt
+++ b/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() and runkit_default_property_add() functions on classes having dynamic properties (without overriding objects)
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties_overriding_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() and runkit_default_property_add() functions on classes having dynamic properties (overriding objects)
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_remove_from_subclasses.phpt
+++ b/tests/runkit_default_property_remove_from_subclasses.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() remove properties from subclasses
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_from_subclasses_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_from_subclasses_overriding_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() remove properties from subclasses overriding objects
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_inheritance.phpt
+++ b/tests/runkit_default_property_remove_inheritance.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() remove properties with inheritance
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--
@@ -42,15 +41,7 @@ runkit_default_property_remove('RunkitSubClass', 'removedProperty');
 runkit_default_property_remove($className, 'removedProperty');
 print_r(new RunkitClass());
 print_r(new RunkitSubClass());
-$out = print_r($obj, true);
-$version = explode(".", PHP_VERSION);
-if ((int) $version[0] == 5 && (int) $version[1] < 4) {
-	$out = preg_replace("/\n\s+\[privateProperty:RunkitClass:private\] => a$/m", "", $out);
-}
-if ((int) $version[0] == 5 && (int) $version[1] < 3) {
-	$out = preg_replace("/\n\s+\[privateProperty:private\] => a$/m", "", $out);
-}
-print $out;
+print_r($obj);
 print_r($obj->getPrivate());
 ?>
 --EXPECTF--

--- a/tests/runkit_default_property_remove_inheritance_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_inheritance_overriding_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() remove properties with inheritance overriding objects
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--
@@ -41,13 +40,6 @@ runkit_default_property_remove($className, 'protectedProperty', TRUE);
 runkit_default_property_remove('RunkitSubClass', 'removedProperty', TRUE);
 runkit_default_property_remove($className, 'removedProperty', TRUE);
 $out = print_r($obj, true);
-/*$version = explode(".", PHP_VERSION);
-if ((int) $version[0] == 5 && (int) $version[1] < 4) {
-	$out = preg_replace("/\n\s+\[privateProperty:RunkitClass:private\] => a$/m", "", $out);
-}
-if ((int) $version[0] == 5 && (int) $version[1] < 3) {
-	$out = preg_replace("/\n\s+\[privateProperty:private\] => a$/m", "", $out);
-}*/
 print $out;
 print_r($obj->getPrivate());
 ?>

--- a/tests/runkit_default_property_remove_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_overriding_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() function overriding objects
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_and_inheritance.phpt
+++ b/tests/runkit_default_property_remove_private_and_inheritance.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() remove private properties with inheritance
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_and_inheritance_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_private_and_inheritance_overriding_objects.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() remove private properties with inheritance overriding objects
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_shadow_and_inheritance.phpt
+++ b/tests/runkit_default_property_remove_private_shadow_and_inheritance.phpt
@@ -2,9 +2,6 @@
 runkit_default_property_remove() remove private properties with inheritance
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      $version = explode(".", PHP_VERSION);
-      if($version[0] < 5) print "skip";
-      if($version[0] == 5 && $version[1] >= 4) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_shadow_and_inheritance54.phpt
+++ b/tests/runkit_default_property_remove_private_shadow_and_inheritance54.phpt
@@ -2,9 +2,6 @@
 runkit_default_property_remove() remove private properties with inheritance
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      $version = explode(".", PHP_VERSION);
-      if($version[0] < 5) print "skip";
-      if($version[0] == 5 && $version[1] < 4) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_shadow_and_inheritance_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_private_shadow_and_inheritance_overriding_objects.phpt
@@ -2,8 +2,6 @@
 runkit_default_property_remove() remove private properties with inheritance with objects overriding
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      $version = explode(".", PHP_VERSION);
-      if($version[0] < 5) print "skip";
 	  if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_simple.phpt
+++ b/tests/runkit_default_property_remove_simple.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_remove() function
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode(".", PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_finally.phpt
+++ b/tests/runkit_finally.phpt
@@ -3,7 +3,6 @@ copy method with finally
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.5.0', '<')) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_function_add_closure.phpt
+++ b/tests/runkit_function_add_closure.phpt
@@ -3,7 +3,6 @@ runkit_method_add() function with closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_add_closure_and_doc_comment.phpt
+++ b/tests/runkit_function_add_closure_and_doc_comment.phpt
@@ -3,7 +3,6 @@ runkit_function_add() closure and doc_comment
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_add_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_function_add_closure_and_doc_comment_from_closure.phpt
@@ -3,7 +3,6 @@ runkit_function_add() closer and doc_comment from closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_redefine_closure_and_doc_comment.phpt
+++ b/tests/runkit_function_redefine_closure_and_doc_comment.phpt
@@ -3,7 +3,6 @@ runkit_function_redefine() closure and doc_comment
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_redefine_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_function_redefine_closure_and_doc_comment_from_closure.phpt
@@ -3,7 +3,6 @@ runkit_function_redefine() closure and doc_comment from closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_redefine_from_anonymous.phpt
+++ b/tests/runkit_function_redefine_from_anonymous.phpt
@@ -3,7 +3,6 @@ runkit_function_redefine() and call from anonymous function
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_function_redefine_var_dump.phpt
+++ b/tests/runkit_function_redefine_var_dump.phpt
@@ -3,7 +3,6 @@ runkit_method_redefine() function with closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_functions_returning_by_reference.phpt
+++ b/tests/runkit_functions_returning_by_reference.phpt
@@ -4,12 +4,6 @@ runkit_function_redefine() & runkit_function_add() for functions returning a val
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT) & (~E_NOTICE));
 
 $a = 0;

--- a/tests/runkit_import_static_properties_override.phpt
+++ b/tests/runkit_import_static_properties_override.phpt
@@ -23,12 +23,6 @@ class Test {
     public function getProtected() { return Test::$o; }
 }
 
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & ~E_DEPRECATED & ~E_STRICT);
 
 $t = new Test;

--- a/tests/runkit_method_add.phpt
+++ b/tests/runkit_method_add.phpt
@@ -6,12 +6,6 @@ runkit_method_add() function
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_method_add_and_doc_comment.phpt
+++ b/tests/runkit_method_add_and_doc_comment.phpt
@@ -6,12 +6,6 @@ runkit_method_add() function and doc_comment
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_method_add_closure.phpt
+++ b/tests/runkit_method_add_closure.phpt
@@ -3,18 +3,11 @@ runkit_method_add() function with closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {}
@@ -31,7 +24,7 @@ class test {
 			echo "c $is $c\nd $is $d\n";
 			echo "g $is $g\n";
 			$d .= ' modified';
-			echo '$this is ';
+			echo '$this=';
 			try {
 				var_dump($this);
 			} catch(Error $e) {
@@ -56,7 +49,7 @@ b is bar
 c is use
 d is ref_use
 g is global
-\$this is 
+\$this=
 (Notice: Undefined variable: this in .* on line [0-9]+|Error: Using \$this when not in object context)
 NULL
 d after call is ref_use modified
@@ -65,5 +58,5 @@ b is bar
 c is use
 d is ref_use modified
 g is global
-\$this is object\(runkit_class\)#2 \(0\) {
+\$this=object\(runkit_class\)#2 \(0\) {
 }

--- a/tests/runkit_method_add_closure2.phpt
+++ b/tests/runkit_method_add_closure2.phpt
@@ -3,7 +3,6 @@ runkit_method_add() function with closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_closure_and_doc_comment.phpt
+++ b/tests/runkit_method_add_closure_and_doc_comment.phpt
@@ -3,7 +3,6 @@ runkit_method_add() function with closure and doc_comment
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_method_add_closure_and_doc_comment_from_closure.phpt
@@ -3,7 +3,6 @@ runkit_method_add() function with closure and doc_comment from closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_closure_and_flags.phpt
+++ b/tests/runkit_method_add_closure_and_flags.phpt
@@ -3,7 +3,6 @@ runkit_method_add() function with closure and flags
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_copy.phpt
+++ b/tests/runkit_method_copy.phpt
@@ -6,12 +6,6 @@ runkit_method_copy() function
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_one {

--- a/tests/runkit_method_copy_and_doc_comment.phpt
+++ b/tests/runkit_method_copy_and_doc_comment.phpt
@@ -6,12 +6,6 @@ runkit_method_copy() function and doc_comment
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_method_redefine.phpt
+++ b/tests/runkit_method_redefine.phpt
@@ -6,12 +6,6 @@ runkit_method_redefine() function
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_method_redefine_and_doc_comment.phpt
+++ b/tests/runkit_method_redefine_and_doc_comment.phpt
@@ -6,12 +6,6 @@ runkit_method_redefine() function and doc_comment
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_method_redefine_closure_and_doc_comment.phpt
+++ b/tests/runkit_method_redefine_closure_and_doc_comment.phpt
@@ -3,7 +3,6 @@ runkit_method_redefine() function with closure and doc_comment
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_redefine_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_method_redefine_closure_and_doc_comment_from_closure.phpt
@@ -3,7 +3,6 @@ runkit_method_redefine() function with closure and doc_comment from closure
 --SKIPIF--
 <?php
 	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-	if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_redefine_update_proto.phpt
+++ b/tests/runkit_method_redefine_update_proto.phpt
@@ -2,7 +2,6 @@
 runkit_method_redefine() must also update children methods' prototypes
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_method_redefine_update_proto2.phpt
+++ b/tests/runkit_method_redefine_update_proto2.phpt
@@ -1,7 +1,5 @@
 --TEST--
 runkit_method_redefine() must also update method's prototype
---SKIPIF--
-<?php if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_method_redefine_with_static_vars.phpt
+++ b/tests/runkit_method_redefine_with_static_vars.phpt
@@ -6,12 +6,6 @@ redefining methods with static variables
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 

--- a/tests/runkit_method_remove.phpt
+++ b/tests/runkit_method_remove.phpt
@@ -6,12 +6,6 @@ runkit_method_remove() function
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_method_rename.phpt
+++ b/tests/runkit_method_rename.phpt
@@ -6,12 +6,6 @@ runkit_method_rename() function
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_method_rename_inheritance.phpt
+++ b/tests/runkit_method_rename_inheritance.phpt
@@ -6,12 +6,6 @@ runkit_method_rename() function and inheritance
 display_errors=on
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 class runkit_class {

--- a/tests/runkit_methods_returning_by_reference.phpt
+++ b/tests/runkit_methods_returning_by_reference.phpt
@@ -4,12 +4,6 @@ runkit_method_redefine() & runkit_method_add() for methods returning a value by 
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
-if (!defined('E_STRICT')) {
-	define('E_STRICT', 0);
-}
-if (!defined('E_DEPRECATED')) {
-	define('E_DEPRECATED', 0);
-}
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT) & (~E_NOTICE));
 
 class RunkitClass {

--- a/tests/runkit_remove_magic_call_method.phpt
+++ b/tests/runkit_remove_magic_call_method.phpt
@@ -2,7 +2,6 @@
 removing magic __call method
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_callstatic_method.phpt
+++ b/tests/runkit_remove_magic_callstatic_method.phpt
@@ -2,8 +2,6 @@
 removing magic __callstatic method
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
-      if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_serialize_method.phpt
+++ b/tests/runkit_remove_magic_serialize_method.phpt
@@ -2,7 +2,6 @@
 removing magic serialize method
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_tostring_method.phpt
+++ b/tests/runkit_remove_magic_tostring_method.phpt
@@ -2,7 +2,6 @@
 removing magic __tostring method
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_unserialize_method.phpt
+++ b/tests/runkit_remove_magic_unserialize_method.phpt
@@ -2,7 +2,6 @@
 removing magic unserialize method
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_static_property_add.phpt
+++ b/tests/runkit_static_property_add.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() function for static properties
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_static_property_add_existing.phpt
+++ b/tests/runkit_static_property_add_existing.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() function for existing static properties
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_static_property_add_single.phpt
+++ b/tests/runkit_static_property_add_single.phpt
@@ -2,7 +2,6 @@
 runkit_default_property_add() function - static override
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_static_property_add_to_subclasses.phpt
+++ b/tests/runkit_static_property_add_to_subclasses.phpt
@@ -2,7 +2,6 @@
 runkit_static_property_add() add properties to subclasses
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
-      if(array_shift(explode('.', PHP_VERSION)) < 5) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_superglobals.phpt
+++ b/tests/runkit_superglobals.phpt
@@ -13,16 +13,7 @@ function testme() {
 	echo "Baz is $baz\n";
 }
 
-$v = explode(".", PHP_VERSION);
-if (array_shift($v) >= 5) {
-	if (!defined('E_STRICT')) {
-		define('E_STRICT', 0);
-	}
-	if (!defined('E_DEPRECATED')) {
-		define('E_DEPRECATED', 0);
-	}
-	ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
-}
+ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
 
 $foo = 1;
 $bar = 2;


### PR DESCRIPTION
And don't define constants such as E_STRICT, etc. that are available in
7.0+