### PR TITLE
Add php 7.1 support for manipulating protected/private class constants

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -67,6 +67,7 @@ Define customized superglobal variables for general purpose use.
     <file name="runkit_constant_add_array.phpt" role="test" />
     <file name="runkit_constant_add_array_to_class.phpt" role="test" />
     <file name="runkit_constant_add.phpt" role="test" />
+    <file name="runkit_constant_add_protected.phpt" role="test" />
     <file name="runkit_constant_add_to_class.phpt" role="test" />
     <file name="runkit_constant_redefine_in_class.phpt" role="test" />
     <file name="runkit_constant_redefine.phpt" role="test" />

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -83,6 +83,16 @@ static inline void* _debug_emalloc(void* data, int bytes, char* file, int line) 
 #include "Zend/zend_object_handlers.h"
 #endif
 
+#if PHP_VERSION_ID >= 70100
+#define RUNKIT_CONST_FLAGS_DC(access_type) , zend_long access_type
+#define RUNKIT_CONST_FLAGS_CC(access_type) , access_type
+#define RUNKIT_CONST_FETCH(access_type) access_type
+#else
+#define RUNKIT_CONST_FLAGS_DC(access_type)
+#define RUNKIT_CONST_FLAGS_CC(access_type)
+#define RUNKIT_CONST_FETCH(access_type) ZEND_ACC_PUBLIC
+#endif
+
 extern zend_module_entry runkit_module_entry;
 #define phpext_runkit_ptr &runkit_module_entry
 
@@ -245,8 +255,8 @@ int php_runkit_fetch_interface(zend_string *classname, zend_class_entry **pce TS
 #define PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR php_error_docref(NULL TSRMLS_CC, E_ERROR, "Not enough memory")
 
 /* runkit_constants.c */
-void php_runkit_update_children_consts(zend_class_entry *ce, zend_class_entry *parent_class, zval *c, zend_string *cname, int access_type);
-void php_runkit_update_children_consts_foreach(HashTable *ht, zend_class_entry *parent_class, zval *c, zend_string *cname, int access_type);
+void php_runkit_update_children_consts(zend_class_entry *ce, zend_class_entry *parent_class, zval *c, zend_string *cname RUNKIT_CONST_FLAGS_DC(access_type));
+void php_runkit_update_children_consts_foreach(HashTable *ht, zend_class_entry *parent_class, zval *c, zend_string *cname RUNKIT_CONST_FLAGS_DC(access_type));
 
 /* runkit_classes.c */
 int php_runkit_class_copy(zend_class_entry *src, zend_string *classname TSRMLS_DC);

--- a/runkit-api.php
+++ b/runkit-api.php
@@ -22,9 +22,10 @@ const RUNKIT_VERSION              = "1.0.5a2";
  *
  * @param string $constname Name of constant to declare. Either a string to indicate a global constant, or classname::constname to indicate a class constant.
  * @param mixed $value null, Bool, Long, Double, String, Resource, or Array value to store in the new constant.
+ * @param int $visibility - Visibility of the constant. Public by default.
  * @return bool - TRUE on success or FALSE on failure.
  */
-function runkit_constant_add(string $constname, $value) : bool {
+function runkit_constant_add(string $constname, $value, int $visibility = RUNKIT_ACC_PUBLIC) : bool {
 }
 
 /**
@@ -35,9 +36,10 @@ function runkit_constant_add(string $constname, $value) : bool {
  *
  * @param string $constname Name of constant to declare. Either a string to indicate a global constant, or classname::constname to indicate a class constant.
  * @param mixed $value null, Bool, Long, Double, String, Resource, or Array value to store in the new constant.
+ * @param int|null $newVisibility The new visibility of the constant. Unchanged by default.
  * @return bool - TRUE on success or FALSE on failure.
  */
-function runkit_constant_redefine(string $constname, $value) : bool {
+function runkit_constant_redefine(string $constname, $value, int $newVisibility = null) : bool {
 }
 
 /**
@@ -50,7 +52,7 @@ function runkit_constant_redefine(string $constname, $value) : bool {
  * @param mixed $value null, Bool, Long, Double, String, or Resource value to store in the new constant.
  * @return bool - TRUE on success or FALSE on failure.
  */
-function runkit_constant_redefine(string $constname, $value) : bool {
+function runkit_constant_remove(string $constname, $value) : bool {
 }
 
 /**

--- a/tests/runkit_constant_add_protected.phpt
+++ b/tests/runkit_constant_add_protected.phpt
@@ -1,0 +1,89 @@
+--TEST--
+runkit_constant_redefine() function redefines protected class constants (when accessing other files, not working for same file)
+--SKIPIF--
+<?php
+if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+if (PHP_MAJOR_VERSION == 7 && PHP_MINOR_VERSION == 0) { print "skip no const visibility in 7.0"; }
+?>
+--FILE--
+<?php
+// For this test case to actually work (The php compiler, not opcache, does this optimization), the code would need to be compiled with ZEND_COMPILE_NO_CONSTANT_SUBSTITUTION | ZEND_COMPILE_NO_PERSISTENT_CONSTANT_SUBSTITUTION
+// That requires either patching php-src or triggering recompilation of code in affected class and in subclasses.
+class TestClass {
+	public static function get_foo() {
+		// missing unless added by runkit
+		return self::_FOO;
+	}
+}
+
+class TestSubclass extends TestClass {
+	public static function get_parent_foo() {
+		// missing unless added by runkit
+		return self::_FOO;
+	}
+}
+
+function access_protected_constant() {
+	try {
+		$x = TestClass::_FOO;
+		printf("Fetched constant, value=%s\n", var_export($x, true));
+	} catch (Error $e) {
+		printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+	}
+}
+
+error_reporting(E_ALL);
+
+access_protected_constant();
+$const = 'TestClass::_FOO';
+try {
+	$x = TestClass::get_foo();
+} catch (Error $e) {
+	printf("Caught %s from get_foo: %s\n", get_class($e), $e->getMessage());
+}
+runkit_constant_add($const, 'roh', RUNKIT_ACC_PROTECTED);
+var_dump($const);
+var_dump(TestClass::get_foo());
+var_dump(TestSubclass::get_foo());
+access_protected_constant();
+// TODO: Remove public/protected constants from subclasses automatically, if they're the same value and visibility?
+// I forget if upstream does this.
+runkit_constant_remove('TestSubclass::_FOO');
+runkit_constant_remove($const);
+try {
+	var_dump(TestClass::get_foo());
+	echo "Unexpectedly able to fetch removed constant from TestClass\n";
+} catch (Error $e) {
+	printf("Caught %s from get_foo: %s\n", get_class($e), $e->getMessage());
+}
+try {
+	var_dump(TestSubclass::get_parent_foo());
+	echo "Unexpectedly able to fetch removed constant from TestSubclass::get_parent_foo()\n";
+} catch (Error $e) {
+	printf("Caught %s from TestSubclass::get_parent_foo: %s\n", get_class($e), $e->getMessage());
+}
+runkit_constant_add($const, 'dah', RUNKIT_ACC_PRIVATE);
+var_dump($const);
+var_dump(TestClass::get_foo());
+var_dump(TestSubclass::get_foo());
+try {
+	var_dump(TestSubclass::get_parent_foo());
+	echo "Unexpectedly able to fetch private constant of TestClass from a method declared in TestSubclass\n";
+} catch (Error $e) {
+	printf("Caught %s from TestSubclass::get_parent_foo: %s\n", get_class($e), $e->getMessage());
+}
+
+?>
+--EXPECT--
+Caught Error: Undefined class constant '_FOO'
+Caught Error from get_foo: Undefined class constant '_FOO'
+string(15) "TestClass::_FOO"
+string(3) "roh"
+string(3) "roh"
+Caught Error: Cannot access protected const TestClass::_FOO
+Caught Error from get_foo: Undefined class constant '_FOO'
+Caught Error from TestSubclass::get_parent_foo: Undefined class constant '_FOO'
+string(15) "TestClass::_FOO"
+string(3) "dah"
+string(3) "dah"
+Caught Error from TestSubclass::get_parent_foo: Undefined class constant '_FOO'

--- a/tests/runkit_constant_redefine_protected_across_file.phpt
+++ b/tests/runkit_constant_redefine_protected_across_file.phpt
@@ -16,6 +16,16 @@ class TestClass extends TestBaseClass{
 	}
 }
 
+
+function access_protected_constant() {
+	try {
+		$x = TestClass::_FOO;
+		printf("Fetched constant, value=%s\n", var_export($x, true));
+	} catch (Error $e) {
+		printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+	}
+}
+access_protected_constant();
 $const = 'TestBaseClass::_FOO';
 var_dump($const, TestClass::get_foo());
 runkit_constant_redefine($const, 'roh');
@@ -27,9 +37,15 @@ runkit_constant_redefine($const, ['dah']);
 var_dump($const, TestClass::get_foo());
 runkit_constant_redefine($const, 2);
 var_dump($const, TestClass::get_foo());
+access_protected_constant();
+// Redefine it as public, and the access should then work.
+runkit_constant_redefine($const, "bar", RUNKIT_ACC_PUBLIC);
+var_dump($const, TestClass::get_foo());
+access_protected_constant();
 // TODO test subclass
 ?>
 --EXPECT--
+Caught Error: Cannot access protected const TestClass::_FOO
 string(19) "TestBaseClass::_FOO"
 string(3) "foo"
 string(19) "TestBaseClass::_FOO"
@@ -43,3 +59,7 @@ array(1) {
 }
 string(19) "TestBaseClass::_FOO"
 int(2)
+Caught Error: Cannot access protected const TestClass::_FOO
+string(19) "TestBaseClass::_FOO"
+string(3) "bar"
+Fetched constant, value='bar'


### PR DESCRIPTION
Fix bug in runkit_constant_redefine: Preserve old visibility of class
constants.

Add null|RUNKIT_ACC_PUBLIC|RUNKIT_ACC_PROTECTED|RUNKIT_ACC_PRIVATE
as possible visibilities for runkit_constant_add/redefine.
- add will default to public, redefine will default to the old
  visibility.