### PR TITLE
Add dependency for runkit superglobals test on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,10 @@ env:
   - CC=gcc-4.8 CXX=g++-4.8 VALGRIND=1
   # Some bugs in runkit only show up without zts enabled. (aka NTS)
   # Specifying PHP_VERSION is done to keep up to date versions in 7.0 and 7.1 (Does it work?)
-  - CC=gcc-4.8 CXX=g++-4.8 VALGRIND=1 PHP_NTS_USE=1 PHP_CONFIGURE_ARGS='--disable-all --disable-zts --enable-debug'
+  # Add --enable-session so $_SESSION will exist in runkit superglobal test
+  - CC=gcc-4.8 CXX=g++-4.8 VALGRIND=1 PHP_NTS_USE=1 PHP_CONFIGURE_ARGS='--disable-all --disable-zts --enable-debug --enable-session'
   # The VM implementation is different on 32-bit php. Test those as well.
-  - CC=gcc-4.8 CXX=g++-4.8 USE_32BIT=1 VALGRIND=1 PHP_NTS_USE=actually-zts PHP_CONFIGURE_ARGS='--disable-all --enable-maintainer-zts --enable-debug'
+  - CC=gcc-4.8 CXX=g++-4.8 USE_32BIT=1 VALGRIND=1 PHP_NTS_USE=actually-zts PHP_CONFIGURE_ARGS='--disable-all --enable-maintainer-zts --enable-debug --enable-session'
 
 install:
   - sudo apt-get install -qq $CC

--- a/tests/runkit_superglobals_obj.phpt
+++ b/tests/runkit_superglobals_obj.phpt
@@ -2,6 +2,7 @@
 runkit.superglobal setting creates superglobals that can be referenced multiple ways.
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("session")) print "skip - This test assumes \$_SESSION will exist, but the session extension isn't enabled/installed"; ?>
 --INI--
 display_errors=on
 runkit.superglobal=foo


### PR DESCRIPTION
And skip the test if $_SESSION would not exist.