### PR TITLE
Add more libraries using runkit7/runkit7. Add short descriptions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,10 @@ Examples
 
 The following mocking libraries work with the runkit7 fork
 
-- [![Build Status](https://travis-ci.org/runkit7/Timecop-PHP.svg?branch=master)](https://travis-ci.org/runkit7/Timecop-PHP) [timecop-PHP (Fork)](https://github.com/runkit7/Timecop-PHP) (requires `runkit.internal_override=1`, suggested only for unit tests)
-- [![Build Status](https://travis-ci.org/runkit7/staticmock.svg?branch=master)](https://travis-ci.org/runkit7/staticmock) [staticmock (Fork)](https://github.com/runkit7/staticmock)
+- [![Build Status](https://travis-ci.org/runkit7/Timecop-PHP.svg?branch=master)](https://travis-ci.org/runkit7/Timecop-PHP) [timecop-PHP (Fork)](https://github.com/runkit7/Timecop-PHP), a time testing library inspired by the ruby timecop gem (requires `runkit.internal_override=1`, suggested only for unit tests)
+- [![Build Status](https://travis-ci.org/tototoshi/staticmock.svg?branch=master)](https://travis-ci.org/tototoshi/staticmock) [staticmock](https://github.com/tototoshi/staticmock), a mockery-like DSL to replace static methods in tests.
+- [![Build Status](https://travis-ci.org/runkit7/SimpleStaticMock.svg?branch=master)](https://travis-ci.org/runkit7/SimpleStaticMock) [SimpleStaticMock (Fork)](https://github.com/runkit7/SimpleStaticMock), a very simple class to mock static methods in unit tests. Unrelated to tototoshi/staticmock. Has patches to work in php 7.1.
+- [![Build Status](https://travis-ci.org/runkit7/TraceOn.svg?branch=master)](https://travis-ci.org/runkit7/TraceOn) [TraceOn (Fork)](https://github.com/runkit7/TraceOn), a simple PHP utility to trace(investigate) invocations of instance/static/global methods.
 
 ## PHP7 SPECIFIC DETAILS
 


### PR DESCRIPTION
Switch the staticmock repo back to upstream tototoshi/staticmock,
it's compatible with both runkit implementations and there's no difference.
(Haven't tested staticmock's interactions with nullable types or void return
types)