### PR TITLE
Add (disabled) spl_object_id() implementation for php <= 7.1, update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ php:
 
 before_script:
  - $CC --version && ci/print_php_int_max.php
- - (export CC; phpize && ./configure && make)
+ - (export CC; phpize && ./configure --enable-runkit-spl_object-id && make)
 
 script:
  - phpenv config-rm xdebug.ini || true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,12 @@
 version: '{branch}.{build}'
 install:
 - cmd: choco feature enable -n=allowGlobalConfirmation
-- cmd: cinst wget
 - cmd: mkdir %APPVEYOR_BUILD_FOLDER%\bin
 build_script:
 - cmd: >-
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
 
-    wget http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
+    appveyor DownloadFile http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
 
     7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
 
@@ -23,7 +22,7 @@ build_script:
 
     xcopy %APPVEYOR_BUILD_FOLDER% C:\projects\php-src\ext\runkit /s /e /y
 
-    wget http://windows.php.net/downloads/php-sdk/deps-7.1-vc14-x86.7z
+    appveyor DownloadFile http://windows.php.net/downloads/php-sdk/deps-7.1-vc14-x86.7z
 
     7z x -y deps-7.1-vc14-x86.7z -oC:\projects\php-src
 
@@ -31,7 +30,7 @@ build_script:
 
     buildconf.bat
 
-    configure.bat --disable-all --enable-session --enable-debug --enable-cli --enable-cgi --enable-runkit --enable-json --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\bin\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\bin --with-php-build=deps
+    configure.bat --disable-all --enable-session --enable-debug --enable-cli --enable-cgi --enable-runkit --enable-runkit-spl_object_id --enable-json --with-config-file-scan-dir=%APPVEYOR_BUILD_FOLDER%\bin\modules.d --with-prefix=%APPVEYOR_BUILD_FOLDER%\bin --with-php-build=deps
 
     nmake
 

--- a/config.m4
+++ b/config.m4
@@ -10,6 +10,10 @@ PHP_ARG_ENABLE(runkit-modify, whether to enable runtime manipulation of function
 PHP_ARG_ENABLE(runkit-super, whether to enable registration of user-defined autoglobals,
 [  --enable-runkit-super     Enable registration of user-defined autoglobals], inherit, no)
 
+PHP_ARG_ENABLE(runkit_spl_object_id, whether to enable spl_object_id in PHP <= 7.1,
+[  --enable-runkit-spl_object_id    Enable spl_object_id support], no, no)
+
+
 if test "$PHP_RUNKIT" != "no"; then
   if test "$PHP_RUNKIT_MODIFY" = "inherit"; then
     PHP_RUNKIT_MODIFY=yes
@@ -42,6 +46,9 @@ if test "$PHP_RUNKIT" != "no"; then
   fi
   if test "$PHP_RUNKIT_SUPER" != "no"; then
     AC_DEFINE(PHP_RUNKIT_FEATURE_SUPER, 1, [Whether to export custom autoglobal registration feature])
+  fi
+  if test "$PHP_RUNKIT_SPL_OBJECT_ID" != "no"; then
+    AC_DEFINE(PHP_RUNKIT_SPL_OBJECT_ID, 1, [Whether to define spl_object_id in php <= 7.1])
   fi
   PHP_NEW_EXTENSION(runkit, runkit.c runkit_functions.c runkit_methods.c \
 runkit_constants.c \

--- a/config.w32
+++ b/config.w32
@@ -12,6 +12,6 @@ ARG_ENABLE("runkit-spl_object_id", "Enable spl_object_id alias of runkit_object_
 if (PHP_RUNKIT != "no") {
 	AC_DEFINE("PHP_RUNKIT_FEATURE_MODIFY", PHP_RUNKIT_MODIFY == "yes", "Runkit Manipulation");
 	AC_DEFINE("PHP_RUNKIT_FEATURE_SUPER", PHP_RUNKIT_SUPER == "yes", "Runkit Superglobals");
-	AC_DEFINE("PHP_RUNKIT_SPL_OBJECT_ID", PHP_RUNKIT_OBJECT_ID == "yes", "Runkit spl_object_id substitute");
+	AC_DEFINE("PHP_RUNKIT_SPL_OBJECT_ID", PHP_RUNKIT_SPL_OBJECT_ID == "yes", "Runkit spl_object_id substitute");
 	EXTENSION("runkit", "runkit.c runkit_functions.c runkit_methods.c runkit_constants.c runkit_object_id.c runkit_common.c runkit_zend_execute_API.c");
 }

--- a/config.w32
+++ b/config.w32
@@ -4,11 +4,14 @@
 ARG_ENABLE("runkit", "Enable runkit support", "no");
 ARG_ENABLE("runkit-modify", "Disable runtime manipulation", "yes");
 ARG_ENABLE("runkit-super", "Disable registration of user-defined autoglobals", "yes");
+ARG_ENABLE("runkit-spl_object_id", "Enable spl_object_id alias of runkit_object_id in php <= 7.1", "no");
+
 // The sandbox and the associated code was disabled for php 7.
 // ARG_ENABLE("runkit-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
 
 if (PHP_RUNKIT != "no") {
 	AC_DEFINE("PHP_RUNKIT_FEATURE_MODIFY", PHP_RUNKIT_MODIFY == "yes", "Runkit Manipulation");
 	AC_DEFINE("PHP_RUNKIT_FEATURE_SUPER", PHP_RUNKIT_SUPER == "yes", "Runkit Superglobals");
+	AC_DEFINE("PHP_RUNKIT_SPL_OBJECT_ID", PHP_RUNKIT_OBJECT_ID == "yes", "Runkit spl_object_id substitute");
 	EXTENSION("runkit", "runkit.c runkit_functions.c runkit_methods.c runkit_constants.c runkit_object_id.c runkit_common.c runkit_zend_execute_API.c");
 }

--- a/package.xml
+++ b/package.xml
@@ -227,6 +227,7 @@ Define customized superglobal variables for general purpose use.
     <file name="runkit_superglobals_obj.phpt" role="test" />
     <file name="runkit_user_functions_on_shutdown.phpt" role="test" />
     <file name="runkit_zval_inspect.phpt" role="test" />
+    <file name="spl_object_id.phpt" role="test" />
    </dir> <!-- //tests -->
    <file name="config.m4" role="src" />
    <file name="config.w32" role="src" />

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -75,6 +75,12 @@ static inline void* _debug_emalloc(void* data, int bytes, char* file, int line) 
 /* Hardcoded. TODO should not be. */
 #define PHP_RUNKIT_SUPERGLOBALS
 
+#ifdef PHP_RUNKIT_SPL_OBJECT_ID
+#if PHP_VERSION_ID < 70200
+#define PHP_RUNKIT_PROVIDES_SPL_OBJECT_ID
+#endif
+#endif
+
 #ifdef PHP_RUNKIT_FEATURE_MODIFY
 #define PHP_RUNKIT_MANIPULATION
 #endif
@@ -103,6 +109,9 @@ PHP_RSHUTDOWN_FUNCTION(runkit);
 PHP_MINFO_FUNCTION(runkit);
 
 PHP_FUNCTION(runkit_object_id);
+#ifdef PHP_RUNKIT_PROVIDES_SPL_OBJECT_ID
+PHP_FUNCTION(spl_object_id);
+#endif
 
 #ifdef PHP_RUNKIT_MANIPULATION
 PHP_FUNCTION(runkit_function_add);

--- a/runkit-api.php
+++ b/runkit-api.php
@@ -244,12 +244,26 @@ function runkit_method_rename(string $classname, string $methodname, string $new
 
 /**
  * Gets a unique integer identifier (Will be reused when the object is garbage collected) for an object.
+ * This is identical to `spl_object_id`, which will be built into PHP 7.2+.
+ * Similar to `spl_object_hash`, but returns an int instead of a string.
+ *
+ * @param object $obj - The object
+ * @return int|false - Returns false if given a non-object.
+ */
+function runkit_object_id($obj) : int {
+}
+
+/**
+ * Gets a unique integer identifier (Will be reused when the object is garbage collected) for an object.
  * This is similar to `spl_object_hash`, but returns an int instead of a string.
+ *
+ * NOTE: runkit can provide an optional native implementation, but that is currently disabled by default by `./configure`.
+ *       spl_object_id is built into PHP 7.2+.
  *
  * @param object $obj - The object
  * @return int|null - Returns null if given a non-object.
  */
-function runkit_object_id($obj) : int {
+function spl_object_id($obj) : int {
 }
 
 /**

--- a/runkit.c
+++ b/runkit.c
@@ -194,6 +194,9 @@ zend_function_entry runkit_functions[] = {
 
 	PHP_FE(runkit_zval_inspect,										arginfo_runkit_zval_inspect)
 	PHP_FE(runkit_object_id,										arginfo_runkit_object_id)
+#ifdef PHP_RUNKIT_PROVIDES_SPL_OBJECT_ID
+	PHP_FE(spl_object_id,											arginfo_runkit_object_id)
+#endif
 
 #ifdef PHP_RUNKIT_SUPERGLOBALS
 	PHP_FE(runkit_superglobals,										arginfo_runkit_superglobals)
@@ -600,6 +603,16 @@ PHP_MINFO_FUNCTION(runkit)
 #else
 	php_info_print_table_header(2, "Runtime Manipulation", "disabled or unavailable");
 #endif /* PHP_RUNKIT_MANIPULATION */
+
+	php_info_print_table_header(2, "spl_object_id alias support",
+#ifdef PHP_RUNKIT_PROVIDES_SPL_OBJECT_ID
+			"enabled"
+#elif PHP_VERSION_ID >= 70200
+			"unnecessary in php 7.2+"
+#else
+			"disabled"
+#endif
+	);
 
 	php_info_print_table_end();
 

--- a/runkit_object_id.c
+++ b/runkit_object_id.c
@@ -35,6 +35,22 @@ PHP_FUNCTION(runkit_object_id)
 }
 /* }}} */
 
+#ifdef PHP_RUNKIT_PROVIDES_SPL_OBJECT_ID
+/* {{{ proto int spl_object_id(object instance)
+Fetch the Object Handle ID from an instance */
+PHP_FUNCTION(spl_object_id)
+{
+	zval *obj;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT(obj)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_NULL());
+
+	RETURN_LONG(Z_OBJ_HANDLE_P(obj));
+}
+/* }}} */
+#endif
+
 /*
  * Local variables:
  * tab-width: 4

--- a/tests/spl_object_id.phpt
+++ b/tests/spl_object_id.phpt
@@ -1,0 +1,50 @@
+--TEST--
+spl_object_id should fetch the object handle.
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID >= 70200) exit("skip redundant test in php 7.2");
+if (!extension_loaded("runkit")) exit("skip");
+if (!function_exists("spl_object_id")) exit("skip");
+?>
+--INI--
+error_reporting=E_ALL
+--FILE--
+<?php
+var_dump(spl_object_id(array()));
+var_dump(spl_object_id(null));
+var_dump(spl_object_id(false));
+var_dump(spl_object_id(true));
+var_dump(spl_object_id(42));
+var_dump(spl_object_id(1.5));
+var_dump(spl_object_id('x'));
+$x = new stdClass();
+$y = new stdClass();
+var_dump(spl_object_id($x));
+var_dump(spl_object_id($y));
+var_dump(spl_object_id($x));
+
+?>
+--EXPECTF--
+Warning: spl_object_id() expects parameter 1 to be object, array given in %s on line %d
+NULL
+
+Warning: spl_object_id() expects parameter 1 to be object, null given in %s on line %d
+NULL
+
+Warning: spl_object_id() expects parameter 1 to be object, boolean given in %s on line %d
+NULL
+
+Warning: spl_object_id() expects parameter 1 to be object, boolean given in %s on line %d
+NULL
+
+Warning: spl_object_id() expects parameter 1 to be object, integer given in %s on line %d
+NULL
+
+Warning: spl_object_id() expects parameter 1 to be object, %s given in %s on line %d
+NULL
+
+Warning: spl_object_id() expects parameter 1 to be object, string given in %s on line %d
+NULL
+int(1)
+int(2)
+int(1)


### PR DESCRIPTION
In PHP 7.2, a native implementation of spl_object_id will be added
This is similar to runkit_object_id, except for returning null instead
of false on failure.

This can be enabled with `./configure --enable-runkit-spl_object_id`