### PR TITLE
Incomplete work on porting runkit_lint to php 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,10 @@ install:
   - sudo apt-get install -qq $CC
   - $CC --version
   - if [ "x$USE_32BIT" != "x" ]; then sudo apt-get install -y g++-4.8-multilib libc6-dev-i386; export CC="$PWD/ci/gcc-32.sh"; export CXX="$PWD/ci/g++-32.sh"; $CC --version;  fi
-  # For NTS builds: Install NTS and set the php.ini to a different blank file.
-  - if [ "x$PHP_NTS_USE" != "x" ]; then export PHP_NTS_VERSION=$(./ci/get_global_php_version.sh); echo "Version is $PHP_NTS_VERSION"; ./ci/install_php_nts.sh || exit 1; export PATH="$(./ci/generate_php_install_dir.sh)/bin:$PATH"; export PHPRC=$PWD/ci/; else ./ci/wipe_travis_cache.sh; fi
   # Test some builds with valgrind to check for memory leaks and invalid memory accesses
   - if [ "$VALGRIND" -eq 1 ]; then sudo apt-get install -qq valgrind; export TEST_PHP_ARGS="-m"; valgrind --version; fi
+  # For NTS builds: Install NTS and set the php.ini to a different blank file.
+  - if [ "x$PHP_NTS_USE" != "x" ]; then export PHP_NTS_VERSION=$(./ci/get_global_php_version.sh); echo "Version is $PHP_NTS_VERSION"; ./ci/install_php_nts.sh || exit 1; export PATH="$(./ci/generate_php_install_dir.sh)/bin:$PATH"; export PHPRC=$PWD/ci/; else ./ci/wipe_travis_cache.sh; fi
   - if [ "$VALGRIND" -eq 1 -a "x$USE_32BIT" != "x" ]; then sudo apt-get install -y libc6-dbg:i386; fi
 
 # Defined at https://github.com/php-build/php-build/tree/master/share/php-build/definitions
@@ -47,6 +47,10 @@ before_script:
 script:
  - phpenv config-rm xdebug.ini || true
  - ci/run_tests.sh
+
+branches:
+  only:
+    - master
 
 notifications:
  email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,15 @@
 # Author: Tyson Andre
 
 version: '{branch}.{build}'
+
 install:
 - cmd: choco feature enable -n=allowGlobalConfirmation
 - cmd: mkdir %APPVEYOR_BUILD_FOLDER%\bin
+
+branches:
+  only:
+    - master
+
 build_script:
 - cmd: >-
     "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"

--- a/ci/install_php_nts.sh
+++ b/ci/install_php_nts.sh
@@ -25,8 +25,8 @@ PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
 if [ "$PHP_NTS_NORMAL_VERSION" != "7.2.0" ] ; then
     curl --verbose https://secure.php.net/distributions/$PHP_TAR_FILE -o $PHP_TAR_FILE
 else
-    curl --verbose https://downloads.php.net/~pollita/php-7.2.0beta2.tar.bz2 -o $PHP_TAR_FILE
-    PHP_FOLDER="php-7.2.0beta2"
+    curl --verbose https://downloads.php.net/~remi/php-7.2.0RC3.tar.bz2 -o $PHP_TAR_FILE
+    PHP_FOLDER="php-7.2.0RC3"
 fi
 
 tar xjf $PHP_TAR_FILE

--- a/config.m4
+++ b/config.m4
@@ -13,6 +13,8 @@ PHP_ARG_ENABLE(runkit-super, whether to enable registration of user-defined auto
 PHP_ARG_ENABLE(runkit_spl_object_id, whether to enable spl_object_id in PHP <= 7.1,
 [  --enable-runkit-spl_object_id    Enable spl_object_id support], no, no)
 
+PHP_ARG_ENABLE(runkit-sandbox, whether to enable Sandbox support,
+[  --enable-runkit-sandbox   Enable Runkit_Sandbox (Requires ZTS)], inherit, no)
 
 if test "$PHP_RUNKIT" != "no"; then
   if test "$PHP_RUNKIT_MODIFY" = "inherit"; then
@@ -21,6 +23,9 @@ if test "$PHP_RUNKIT" != "no"; then
   if test "$PHP_RUNKIT_SUPER" = "inherit"; then
     PHP_RUNKIT_SUPER=yes
   fi
+  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
+    PHP_RUNKIT_SANDBOX=yes
+  fi
 else
   if test "$PHP_RUNKIT_MODIFY" = "inherit"; then
     PHP_RUNKIT_MODIFY=no
@@ -28,10 +33,14 @@ else
   if test "$PHP_RUNKIT_SUPER" = "inherit"; then
     PHP_RUNKIT_SUPER=no
   fi
+  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
+    PHP_RUNKIT_SANDBOX=no
+  fi
 fi
 
 if test "$PHP_RUNKIT_MODIFY" = "yes" ||
-   test "$PHP_RUNKIT_SUPER" = "yes"; then
+   test "$PHP_RUNKIT_SUPER" = "yes" ||
+   test "$PHP_RUNKIT_SANDBOX" = "yes"; then
   if test "$PHP_RUNKIT" != "classkit"; then
     PHP_RUNKIT=yes
   fi
@@ -47,12 +56,16 @@ if test "$PHP_RUNKIT" != "no"; then
   if test "$PHP_RUNKIT_SUPER" != "no"; then
     AC_DEFINE(PHP_RUNKIT_FEATURE_SUPER, 1, [Whether to export custom autoglobal registration feature])
   fi
+  if test "$PHP_RUNKIT_SANDBOX" != "no"; then
+    AC_DEFINE(PHP_RUNKIT_FEATURE_SANDBOX, 1, [Whether to export Sandbox feature])
+  fi
   if test "$PHP_RUNKIT_SPL_OBJECT_ID" != "no"; then
     AC_DEFINE(PHP_RUNKIT_SPL_OBJECT_ID, 1, [Whether to define spl_object_id in php <= 7.1])
   fi
   PHP_NEW_EXTENSION(runkit, runkit.c runkit_functions.c runkit_methods.c \
 runkit_import.c \
 runkit_constants.c \
+runkit_sandbox.c runkit_sandbox_parent.c \
 runkit_object_id.c \
 runkit_common.c \
 runkit_zend_execute_API.c \

--- a/config.m4
+++ b/config.m4
@@ -13,8 +13,8 @@ PHP_ARG_ENABLE(runkit-super, whether to enable registration of user-defined auto
 PHP_ARG_ENABLE(runkit_spl_object_id, whether to enable spl_object_id in PHP <= 7.1,
 [  --enable-runkit-spl_object_id    Enable spl_object_id support], no, no)
 
-PHP_ARG_ENABLE(runkit-sandbox, whether to enable Sandbox support,
-[  --enable-runkit-sandbox   Enable Runkit_Sandbox (Requires ZTS)], inherit, no)
+dnl PHP_ARG_ENABLE(runkit-sandbox, whether to enable Sandbox support,
+dnl [  --enable-runkit-sandbox   Enable Runkit_Sandbox (Requires ZTS)], inherit, no)
 
 if test "$PHP_RUNKIT" != "no"; then
   if test "$PHP_RUNKIT_MODIFY" = "inherit"; then
@@ -23,9 +23,9 @@ if test "$PHP_RUNKIT" != "no"; then
   if test "$PHP_RUNKIT_SUPER" = "inherit"; then
     PHP_RUNKIT_SUPER=yes
   fi
-  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
-    PHP_RUNKIT_SANDBOX=yes
-  fi
+dnl  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
+dnl    PHP_RUNKIT_SANDBOX=yes
+dnl  fi
 else
   if test "$PHP_RUNKIT_MODIFY" = "inherit"; then
     PHP_RUNKIT_MODIFY=no
@@ -33,14 +33,14 @@ else
   if test "$PHP_RUNKIT_SUPER" = "inherit"; then
     PHP_RUNKIT_SUPER=no
   fi
-  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
-    PHP_RUNKIT_SANDBOX=no
-  fi
+dnl  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
+dnl    PHP_RUNKIT_SANDBOX=no
+dnl  fi
 fi
 
+dnl   test "$PHP_RUNKIT_SANDBOX" = "yes" ||
 if test "$PHP_RUNKIT_MODIFY" = "yes" ||
-   test "$PHP_RUNKIT_SUPER" = "yes" ||
-   test "$PHP_RUNKIT_SANDBOX" = "yes"; then
+   test "$PHP_RUNKIT_SUPER" = "yes"; then
   if test "$PHP_RUNKIT" != "classkit"; then
     PHP_RUNKIT=yes
   fi
@@ -56,16 +56,16 @@ if test "$PHP_RUNKIT" != "no"; then
   if test "$PHP_RUNKIT_SUPER" != "no"; then
     AC_DEFINE(PHP_RUNKIT_FEATURE_SUPER, 1, [Whether to export custom autoglobal registration feature])
   fi
-  if test "$PHP_RUNKIT_SANDBOX" != "no"; then
-    AC_DEFINE(PHP_RUNKIT_FEATURE_SANDBOX, 1, [Whether to export Sandbox feature])
-  fi
+dnl  if test "$PHP_RUNKIT_SANDBOX" != "no"; then
+dnl    AC_DEFINE(PHP_RUNKIT_FEATURE_SANDBOX, 1, [Whether to export Sandbox feature])
+dnl  fi
   if test "$PHP_RUNKIT_SPL_OBJECT_ID" != "no"; then
     AC_DEFINE(PHP_RUNKIT_SPL_OBJECT_ID, 1, [Whether to define spl_object_id in php <= 7.1])
   fi
+dnl runkit_sandbox.c runkit_sandbox_parent.c
   PHP_NEW_EXTENSION(runkit, runkit.c runkit_functions.c runkit_methods.c \
 runkit_import.c \
 runkit_constants.c \
-runkit_sandbox.c runkit_sandbox_parent.c \
 runkit_object_id.c \
 runkit_common.c \
 runkit_zend_execute_API.c \

--- a/config.w32
+++ b/config.w32
@@ -7,12 +7,24 @@ ARG_ENABLE("runkit-super", "Disable registration of user-defined autoglobals", "
 ARG_ENABLE("runkit-spl_object_id", "Enable spl_object_id alias of runkit_object_id in php <= 7.1", "no");
 
 // The sandbox and the associated code was disabled for php 7.
-// ARG_ENABLE("runkit-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
+ARG_ENABLE("runkit-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
 
 if (PHP_RUNKIT != "no") {
 	AC_DEFINE("PHP_RUNKIT_FEATURE_MODIFY", PHP_RUNKIT_MODIFY == "yes", "Runkit Manipulation");
 	AC_DEFINE("PHP_RUNKIT_FEATURE_SUPER", PHP_RUNKIT_SUPER == "yes", "Runkit Superglobals");
 	AC_DEFINE("PHP_RUNKIT_SPL_OBJECT_ID", PHP_RUNKIT_SPL_OBJECT_ID == "yes", "Runkit spl_object_id substitute");
+	AC_DEFINE("PHP_RUNKIT_FEATURE_SANDBOX", PHP_RUNKIT_SANDBOX == "yes", "Runkit Sandbox");
 
-	EXTENSION("runkit", "runkit.c runkit_functions.c runkit_methods.c runkit_import.c runkit_constants.c runkit_object_id.c runkit_common.c runkit_props.c runkit_classes.c runkit_zend_execute_API.c");
+	EXTENSION("runkit", "runkit.c " +
+			"runkit_common.c " +
+			"runkit_functions.c " +
+			"runkit_methods.c" +
+			"runkit_import.c " +
+			"runkit_classes.c " +
+			"runkit_props.c " +
+			"runkit_constants.c " +
+			"runkit_object_id.c " +
+			"runkit_sandbox.c " +
+			"runkit_sandbox_parent.c " +
+			"runkit_zend_execute_API.c ");
 }

--- a/config.w32
+++ b/config.w32
@@ -7,24 +7,24 @@ ARG_ENABLE("runkit-super", "Disable registration of user-defined autoglobals", "
 ARG_ENABLE("runkit-spl_object_id", "Enable spl_object_id alias of runkit_object_id in php <= 7.1", "no");
 
 // The sandbox and the associated code was disabled for php 7.
-ARG_ENABLE("runkit-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
+// ARG_ENABLE("runkit-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
 
 if (PHP_RUNKIT != "no") {
 	AC_DEFINE("PHP_RUNKIT_FEATURE_MODIFY", PHP_RUNKIT_MODIFY == "yes", "Runkit Manipulation");
 	AC_DEFINE("PHP_RUNKIT_FEATURE_SUPER", PHP_RUNKIT_SUPER == "yes", "Runkit Superglobals");
 	AC_DEFINE("PHP_RUNKIT_SPL_OBJECT_ID", PHP_RUNKIT_SPL_OBJECT_ID == "yes", "Runkit spl_object_id substitute");
-	AC_DEFINE("PHP_RUNKIT_FEATURE_SANDBOX", PHP_RUNKIT_SANDBOX == "yes", "Runkit Sandbox");
+	// AC_DEFINE("PHP_RUNKIT_FEATURE_SANDBOX", PHP_RUNKIT_SANDBOX == "yes", "Runkit Sandbox");
 
 	EXTENSION("runkit", "runkit.c " +
 			"runkit_common.c " +
 			"runkit_functions.c " +
-			"runkit_methods.c" +
+			"runkit_methods.c " +
 			"runkit_import.c " +
 			"runkit_classes.c " +
 			"runkit_props.c " +
 			"runkit_constants.c " +
 			"runkit_object_id.c " +
-			"runkit_sandbox.c " +
-			"runkit_sandbox_parent.c " +
+			// "runkit_sandbox.c " +
+			// "runkit_sandbox_parent.c " +
 			"runkit_zend_execute_API.c ");
 }

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -86,8 +86,13 @@ static inline void* _debug_emalloc(void* data, int bytes, char* file, int line) 
 /* The TSRM interpreter patch required by runkit_sandbox was added in 5.1, but this package includes diffs for older versions
  * Those diffs include an additional #define to indicate that they've been applied
  */
-#if defined(ZTS) && defined(PHP_RUNKIT_FEATURE_SANDBOX)
+#ifdef PHP_RUNKIT_FEATURE_SANDBOX
+#if (defined ZTS) && (defined PHP_RUNKIT_FEATURE_SANDBOX)
 #define PHP_RUNKIT_SANDBOX
+#else
+// debugging code
+#error Feature not enabled
+#endif
 #endif
 
 #ifdef PHP_RUNKIT_FEATURE_MODIFY

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -61,6 +61,8 @@ static inline void* _debug_emalloc(void* data, int bytes, char* file, int line) 
 #endif
 
 #define PHP_RUNKIT_VERSION					"1.0.5b1"
+#define PHP_RUNKIT_SANDBOX_CLASSNAME		"Runkit_Sandbox"
+#define PHP_RUNKIT_SANDBOX_PARENT_CLASSNAME	"Runkit_Sandbox_Parent"
 
 #define PHP_RUNKIT_IMPORT_FUNCTIONS                         0x0001
 #define PHP_RUNKIT_IMPORT_CLASS_METHODS                     0x0002
@@ -79,6 +81,13 @@ static inline void* _debug_emalloc(void* data, int bytes, char* file, int line) 
 #if PHP_VERSION_ID < 70200
 #define PHP_RUNKIT_PROVIDES_SPL_OBJECT_ID
 #endif
+#endif
+
+/* The TSRM interpreter patch required by runkit_sandbox was added in 5.1, but this package includes diffs for older versions
+ * Those diffs include an additional #define to indicate that they've been applied
+ */
+#if defined(ZTS) && defined(PHP_RUNKIT_FEATURE_SANDBOX)
+#define PHP_RUNKIT_SANDBOX
 #endif
 
 #ifdef PHP_RUNKIT_FEATURE_MODIFY
@@ -161,14 +170,25 @@ PHP_FUNCTION(runkit_import);
 #endif /* PHP_RUNKIT_MANIPULATION_IMPORT */
 #endif /* PHP_RUNKIT_MANIPULATION */
 
+#ifdef PHP_RUNKIT_SANDBOX
+PHP_FUNCTION(runkit_sandbox_output_handler);
+PHP_FUNCTION(runkit_lint);
+PHP_FUNCTION(runkit_lint_file);
+
+typedef struct _php_runkit_sandbox_object php_runkit_sandbox_object;
+#endif /* PHP_RUNKIT_SANDBOX */
+
 #ifdef PHP_RUNKIT_MANIPULATION
 // typedef struct _php_runkit_default_class_members_list_element php_runkit_default_class_members_list_element;
 #endif
 
-#if defined(PHP_RUNKIT_SUPERGLOBALS) || defined(PHP_RUNKIT_MANIPULATION)
+#if defined(PHP_RUNKIT_SUPERGLOBALS) || defined(PHP_RUNKIT_SANDBOX) || defined(PHP_RUNKIT_MANIPULATION)
 ZEND_BEGIN_MODULE_GLOBALS(runkit)
 #ifdef PHP_RUNKIT_SUPERGLOBALS
 	HashTable *superglobals;
+#endif
+#ifdef PHP_RUNKIT_SANDBOX
+	php_runkit_sandbox_object *current_sandbox;
 #endif
 #ifdef PHP_RUNKIT_MANIPULATION
 	HashTable *misplaced_internal_functions;
@@ -373,6 +393,69 @@ static inline void php_runkit_modify_function_doc_comment(zend_function *fe, zen
 	}
 
 #endif /* PHP_RUNKIT_MANIPULATION */
+
+#ifdef PHP_RUNKIT_SANDBOX
+/* runkit_sandbox.c */
+int php_runkit_init_sandbox(INIT_FUNC_ARGS);
+int php_runkit_shutdown_sandbox(SHUTDOWN_FUNC_ARGS);
+
+/* runkit_sandbox_parent.c */
+int php_runkit_init_sandbox_parent(INIT_FUNC_ARGS);
+int php_runkit_shutdown_sandbox_parent(SHUTDOWN_FUNC_ARGS);
+int php_runkit_sandbox_array_deep_copy(RUNKIT_53_TSRMLS_ARG(zval **value), int num_args, va_list args, zend_hash_key *hash_key);
+
+struct _php_runkit_sandbox_object {
+	zend_object obj;
+
+	void *context, *parent_context;
+
+	char *disable_functions;
+	char *disable_classes;
+	zval *output_handler;					/* points to function which lives in the parent_context */
+
+	unsigned char bailed_out_in_eval;		/* Patricide is an ugly thing.  Especially when it leaves bailout address mis-set */
+
+	unsigned char active;					/* A bailout will set this to 0 */
+	unsigned char parent_access;			/* May Runkit_Sandbox_Parent be instantiated/used? */
+	unsigned char parent_read;				/* May parent vars be read? */
+	unsigned char parent_write;				/* May parent vars be written to? */
+	unsigned char parent_eval;				/* May arbitrary code be run in the parent? */
+	unsigned char parent_include;			/* May arbitrary code be included in the parent? (includes require(), and *_once()) */
+	unsigned char parent_echo;				/* May content be echoed from the parent scope? */
+	unsigned char parent_call;				/* May functions in the parent scope be called? */
+	unsigned char parent_die;				/* Are $PARENT->die() / $PARENT->exit() enabled? */
+	unsigned long parent_scope;				/* 0 == Global, 1 == Active, 2 == Active->prior, 3 == Active->prior->prior, etc... */
+
+	char *parent_scope_name;				/* Combines with parent_scope to refer to a named array as a symbol table */
+	int parent_scope_namelen;
+};
+
+
+/* TODO: It'd be nice if objects and resources could make it across... */
+#define PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(pzv) \
+{ \
+	switch (Z_TYPE_P(pzv)) { \
+		case IS_RESOURCE: \
+		case IS_OBJECT: \
+			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to translate resource, or object variable to current context."); \
+			ZVAL_NULL(pzv); \
+			break; \
+		case IS_ARRAY: \
+		{ \
+			HashTable *original_hashtable = Z_ARRVAL_P(pzv); \
+			array_init(pzv); \
+			zend_hash_apply_with_arguments(RUNKIT_53_TSRMLS_PARAM(original_hashtable), (apply_func_args_t)php_runkit_sandbox_array_deep_copy, 1, Z_ARRVAL_P(pzv) TSRMLS_CC); \
+			break; \
+		} \
+		default: \
+			zval_copy_ctor(pzv); \
+	} \
+	if (Z_REFCOUNTED_P(pzf)) \
+		Z_SET_REFCOUNT(pzv, 1); \
+		/*(pzv)->RUNKIT_IS_REF = 0; // I think I can get rid of that, since IS_REFERENCE is now part of Z_TYPE?*/ \
+	} \
+}
+#endif /* PHP_RUNKIT_SANDBOX */
 
 #ifdef PHP_RUNKIT_MANIPULATION
 
@@ -622,6 +705,18 @@ void php_runkit_update_reflection_object_name(zend_object* object, int handle, c
 		zend_object zo;
 	} reflection_object;
 #endif /* PHP_RUNKIT_MANIPULATION */
+
+#ifdef PHP_RUNKIT_SANDBOX
+// TODO: Figure out what the php7 equivalent of zend_object_store_bucket and zend_object_handle are.
+/* {{{ php_runkit_zend_object_store_get_obj */
+inline static zend_object *php_runkit_zend_object_store_get(const zval *zobject TSRMLS_DC)
+{
+	// Note: Object handle may be removed from _zend_resource in the future.
+	int handle = Z_OBJ_HANDLE_P(zobject);
+	return EG(objects_store).object_buckets[handle];
+}
+/* }}} */
+#endif
 
 #endif	/* PHP_RUNKIT_H */
 

--- a/php_runkit_sandbox.h
+++ b/php_runkit_sandbox.h
@@ -1,0 +1,188 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 7                                                        |
+  +----------------------------------------------------------------------+
+  | (c) 2008-2015 Dmitry Zenovich                                        |
+  +----------------------------------------------------------------------+
+  | This source file is subject to the new BSD license,                  |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.opensource.org/licenses/BSD-3-Clause                      |
+  | If you did not receive a copy of the license and are unable to       |
+  | obtain it through the world-wide-web, please send a note to          |
+  | dzenovich@gmail.com so we can mail you a copy immediately.           |
+  +----------------------------------------------------------------------+
+  | Author: Dmitry Zenovich <dzenovich@gmail.com>                        |
+  +----------------------------------------------------------------------+
+*/
+
+#ifndef PHP_RUNKIT_SANDBOX_H
+#define PHP_RUNKIT_SANDBOX_H
+
+/* {{{ php_runkit_sandbox_has_property_int */
+inline static int php_runkit_sandbox_has_property_int(int has_set_exists, zval *member TSRMLS_DC) {
+	zval **tmpzval;
+	int result = 0;
+
+#if PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 1
+	/* Map PHP 5.0 has_property flag to PHP 5.1+ flag */
+	has_set_exists = (has_set_exists == 0) ? 2 : 1;
+#endif
+
+	if (zend_hash_find(&EG(symbol_table), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void*)&tmpzval) == SUCCESS) {
+		switch (has_set_exists) {
+			case 0:
+				result = (Z_TYPE_PP(tmpzval) != IS_NULL);
+				break;
+			case 1:
+				switch (Z_TYPE_PP(tmpzval)) {
+					case IS_BOOL: case IS_LONG: case IS_RESOURCE:
+						result = (Z_LVAL_PP(tmpzval) != 0);
+						break;
+					case IS_DOUBLE:
+						result = (Z_DVAL_PP(tmpzval) != 0);
+						break;
+					case IS_STRING:
+						result = (Z_STRLEN_PP(tmpzval) > 1 || (Z_STRLEN_PP(tmpzval) == 1 && Z_STRVAL_PP(tmpzval)[0] != '0'));
+						break;
+					case IS_ARRAY:
+						result = zend_hash_num_elements(Z_ARRVAL_PP(tmpzval)) > 0;
+						break;
+					case IS_OBJECT:
+						/* TODO: Use ZE2 logic for this rather than ZE1 logic */
+						result = zend_hash_num_elements(Z_OBJPROP_PP(tmpzval)) > 0;
+						break;
+					case IS_NULL:
+					default:
+						result = 0;
+				}
+				break;
+			case 2:
+				result = 1;
+				break;
+		}
+	} else {
+		result = 0;
+	}
+	return result;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_include_or_eval_int */
+inline static zend_op_array *php_runkit_sandbox_include_or_eval_int(zval *return_value, zval *zcode, int type, int once, int *already_included TSRMLS_DC) {
+	zend_op_array *op_array = NULL;
+
+	if (type == ZEND_EVAL) {
+		/* eval() */
+		char *eval_desc = zend_make_compiled_string_description("Runkit_Sandbox Eval Code" TSRMLS_CC);
+		op_array = compile_string(zcode, eval_desc TSRMLS_CC);
+		efree(eval_desc);
+	} else if (!once) {
+		/* include() & requre() */
+		op_array = compile_filename(type, zcode TSRMLS_CC);
+	} else {
+		/* include_once() & require_once() */
+		int dummy = 1;
+		zend_file_handle file_handle;
+
+		if (SUCCESS == zend_stream_open(Z_STRVAL_P(zcode), &file_handle TSRMLS_CC)) {
+			if (!file_handle.opened_path) {
+				file_handle.opened_path = estrndup(Z_STRVAL_P(zcode), Z_STRLEN_P(zcode));
+			}
+			if (zend_hash_add(&EG(included_files), file_handle.opened_path, strlen(file_handle.opened_path)+1, (void*)&dummy, sizeof(int), NULL)==SUCCESS) {
+				op_array = zend_compile_file(&file_handle, type TSRMLS_CC);
+				zend_destroy_file_handle(&file_handle TSRMLS_CC);
+			} else {
+				RUNKIT_FILE_HANDLE_DTOR(&file_handle);
+				RETVAL_TRUE;
+				*already_included = 1;
+			}
+		}
+	}
+	return op_array;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_call_int */
+inline static void php_runkit_sandbox_call_int(zval *func_name, char **pname, zval **pretval, zval *args, zval *return_value, void *prior_context TSRMLS_DC) {
+	HashPosition pos;
+	int i;
+	zval **tmpzval;
+	int argc = zend_hash_num_elements(Z_ARRVAL_P(args));
+	zval ***sandbox_args = safe_emalloc(sizeof(zval**), argc, 0);
+
+	for(zend_hash_internal_pointer_reset_ex(Z_ARRVAL_P(args), &pos), i = 0;
+		(zend_hash_get_current_data_ex(Z_ARRVAL_P(args), (void*)&tmpzval, &pos) == SUCCESS) && (i < argc);
+		zend_hash_move_forward_ex(Z_ARRVAL_P(args), &pos), i++) {
+		sandbox_args[i] = emalloc(sizeof(zval*));
+		MAKE_STD_ZVAL(*sandbox_args[i]);
+		**sandbox_args[i] = **tmpzval;
+
+		if (Z_TYPE_P(*sandbox_args[i]) == IS_OBJECT && zend_get_class_entry(*sandbox_args[i], prior_context) == zend_ce_closure) {
+			zend_closure *closure;
+			zend_object *bucket;
+			bucket = php_runkit_zend_object_store_get_obj(*sandbox_args[i], prior_context);
+			closure = (zend_closure *) bucket->bucket.obj.object;
+			(*sandbox_args[i])->value.obj.handle = zend_objects_store_put(closure, NULL, NULL, bucket->bucket.obj.clone TSRMLS_CC);
+		} else
+			PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(*sandbox_args[i]);
+	}
+
+	/* Shouldn't be necessary */
+	argc = i;
+
+	/* Note: If this function is disabled by disable_functions or disable_classes,
+	 * The user will get a confusing error message about (null)() being disabled for security reasons on line 0
+	 * This will be fixable with a properly set EG(function_state_ptr)....just not yet
+	 */
+	if (call_user_function_ex(EG(function_table), NULL, func_name, pretval, argc, sandbox_args, 0, NULL TSRMLS_CC) == SUCCESS) {
+		if (*pretval) {
+			*return_value = **pretval;
+		} else {
+			RETVAL_TRUE;
+		}
+	} else {
+		php_error_docref1(NULL TSRMLS_CC, *pname, E_WARNING, "Unable to call function");
+		RETVAL_FALSE;
+	}
+	if (*pname) {
+		efree(*pname);
+		*pname = NULL;
+	}
+
+	for(i = 0; i < argc; i++) {
+		if (Z_TYPE_P(*sandbox_args[i]) == IS_OBJECT && zend_get_class_entry(*sandbox_args[i] TSRMLS_CC) == zend_ce_closure) {
+			zend_object_store_bucket *bucket = php_runkit_zend_object_store_get_obj(*sandbox_args[i] TSRMLS_CC);
+			zend_objects_store_del_ref(*sandbox_args[i] TSRMLS_CC);
+			zval_ptr_dtor(sandbox_args[i]);
+			bucket->bucket.obj.object = NULL;
+		}
+		zval_ptr_dtor(sandbox_args[i]);
+		efree(sandbox_args[i]);
+	}
+	efree(sandbox_args);
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_return_property_value */
+inline static zval *php_runkit_sandbox_return_property_value(int prop_found, zval *retval TSRMLS_DC) {
+	if (prop_found) {
+		zval *return_value;
+
+		ALLOC_ZVAL(return_value);
+		*return_value = *retval;
+
+		/* ZE expects refcount == 0 for unowned values */
+		INIT_PZVAL(return_value);
+		PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(return_value);
+		return_value->RUNKIT_REFCOUNT--;
+
+		return return_value;
+	} else {
+		return EG(uninitialized_zval_ptr);
+	}
+}
+/* }}} */
+
+#endif
+

--- a/php_runkit_sandbox.h
+++ b/php_runkit_sandbox.h
@@ -3,6 +3,7 @@
   | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
   | (c) 2008-2015 Dmitry Zenovich                                        |
+  | "runkit7" patches (c) 2015-2017 Tyson Andre                          |
   +----------------------------------------------------------------------+
   | This source file is subject to the new BSD license,                  |
   | that is bundled with this package in the file LICENSE, and is        |
@@ -10,24 +11,22 @@
   | http://www.opensource.org/licenses/BSD-3-Clause                      |
   | If you did not receive a copy of the license and are unable to       |
   | obtain it through the world-wide-web, please send a note to          |
-  | dzenovich@gmail.com so we can mail you a copy immediately.           |
+  | license@php.net so we can mail you a copy immediately.               |
   +----------------------------------------------------------------------+
   | Author: Dmitry Zenovich <dzenovich@gmail.com>                        |
+  | Modified for php7 by Tyson Andre <tysonandre775@hotmail.com>         |
   +----------------------------------------------------------------------+
 */
 
 #ifndef PHP_RUNKIT_SANDBOX_H
 #define PHP_RUNKIT_SANDBOX_H
 
+// FIXME reintroduce and fix compilation errors
+#if 0
 /* {{{ php_runkit_sandbox_has_property_int */
 inline static int php_runkit_sandbox_has_property_int(int has_set_exists, zval *member TSRMLS_DC) {
 	zval **tmpzval;
 	int result = 0;
-
-#if PHP_MAJOR_VERSION == 5 && PHP_MINOR_VERSION < 1
-	/* Map PHP 5.0 has_property flag to PHP 5.1+ flag */
-	has_set_exists = (has_set_exists == 0) ? 2 : 1;
-#endif
 
 	if (zend_hash_find(&EG(symbol_table), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void*)&tmpzval) == SUCCESS) {
 		switch (has_set_exists) {
@@ -36,7 +35,7 @@ inline static int php_runkit_sandbox_has_property_int(int has_set_exists, zval *
 				break;
 			case 1:
 				switch (Z_TYPE_PP(tmpzval)) {
-					case IS_BOOL: case IS_LONG: case IS_RESOURCE:
+					case IS_FALSE: case IS_TRUE: case IS_LONG: case IS_RESOURCE:
 						result = (Z_LVAL_PP(tmpzval) != 0);
 						break;
 					case IS_DOUBLE:
@@ -183,6 +182,7 @@ inline static zval *php_runkit_sandbox_return_property_value(int prop_found, zva
 	}
 }
 /* }}} */
+#endif // #if 0
 
 #endif
 

--- a/runkit.c
+++ b/runkit.c
@@ -82,6 +82,16 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_runkit_object_id, 0, 0, 1)
 	ZEND_ARG_INFO(0, obj)
 ZEND_END_ARG_INFO()
 
+#if PHP_RUNKIT_SANDBOX
+ZEND_BEGIN_ARG_INFO_EX(arginfo_runkit_lint, 0, 0, 1)
+	ZEND_ARG_INFO(0, contents)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_runkit_lint_file, 0, 0, 1)
+	ZEND_ARG_INFO(0, file_name)
+ZEND_END_ARG_INFO()
+#endif
+
 #ifdef PHP_RUNKIT_SUPERGLOBALS
 ZEND_BEGIN_ARG_INFO(arginfo_runkit_superglobals, 0)
 ZEND_END_ARG_INFO()
@@ -242,9 +252,10 @@ zend_function_entry runkit_functions[] = {
 #endif /* PHP_RUNKIT_MANIPULATION */
 
 #ifdef PHP_RUNKIT_SANDBOX
-	PHP_FE(runkit_sandbox_output_handler,							NULL)
-	PHP_FE(runkit_lint,												NULL)
-	PHP_FE(runkit_lint_file,										NULL)
+	// FIXME re-enable for sandbox
+	// PHP_FE(runkit_sandbox_output_handler,							NULL)
+	PHP_FE(runkit_lint,												arginfo_runkit_lint)
+	PHP_FE(runkit_lint_file,										arginfo_runkit_lint_file)
 #endif
 
 	{NULL, NULL, NULL}
@@ -402,8 +413,9 @@ PHP_MINIT_FUNCTION(runkit)
 
 	return (1)
 #ifdef PHP_RUNKIT_SANDBOX
-		&& (php_runkit_init_sandbox(INIT_FUNC_ARGS_PASSTHRU) == SUCCESS)
-		&& (php_runkit_init_sandbox_parent(INIT_FUNC_ARGS_PASSTHRU) == SUCCESS)
+		// FIXME re-enable sandbox
+		// && (php_runkit_init_sandbox(INIT_FUNC_ARGS_PASSTHRU) == SUCCESS)
+		// && (php_runkit_init_sandbox_parent(INIT_FUNC_ARGS_PASSTHRU) == SUCCESS)
 #endif
 				? SUCCESS : FAILURE;
 }
@@ -423,8 +435,9 @@ PHP_MSHUTDOWN_FUNCTION(runkit)
 
 	return (1)
 #ifdef PHP_RUNKIT_SANDBOX
-		&& (php_runkit_shutdown_sandbox(SHUTDOWN_FUNC_ARGS_PASSTHRU) == SUCCESS)
-		&& (php_runkit_shutdown_sandbox_parent(SHUTDOWN_FUNC_ARGS_PASSTHRU) == SUCCESS)
+		// FIXME re-enable sandbox
+		// && (php_runkit_shutdown_sandbox(SHUTDOWN_FUNC_ARGS_PASSTHRU) == SUCCESS)
+		// && (php_runkit_shutdown_sandbox_parent(SHUTDOWN_FUNC_ARGS_PASSTHRU) == SUCCESS)
 #endif
 				? SUCCESS : FAILURE;
 }

--- a/runkit_sandbox.c
+++ b/runkit_sandbox.c
@@ -1,0 +1,1858 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 7                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2006 The PHP Group, (c) 2008-2015 Dmitry Zenovich |
+  +----------------------------------------------------------------------+
+  | This source file is subject to the new BSD license,                  |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.opensource.org/licenses/BSD-3-Clause                      |
+  | If you did not receive a copy of the license and are unable to       |
+  | obtain it through the world-wide-web, please send a note to          |
+  | dzenovich@gmail.com so we can mail you a copy immediately.           |
+  +----------------------------------------------------------------------+
+  | Author: Sara Golemon <pollita@php.net>                               |
+  | Props:  Wez Furlong                                                  |
+  | Modified by Dmitry Zenovich <dzenovich@gmail.com>                    |
+  +----------------------------------------------------------------------+
+*/
+
+/* $Id$ */
+
+#include "php_runkit.h"
+#include "ext/standard/php_smart_string.h"
+
+#ifdef PHP_RUNKIT_SANDBOX
+#include "SAPI.h"
+#include "php_main.h"
+#include "php_runkit_sandbox.h"
+#include "php_runkit_zval.h"
+
+static zend_object_handlers php_runkit_sandbox_object_handlers;
+static zend_class_entry *php_runkit_sandbox_class_entry;
+
+#define PHP_RUNKIT_SANDBOX_BEGIN(objval) \
+{ \
+	void *prior_context = tsrm_set_interpreter_context(objval->context); \
+	TSRMLS_FETCH();
+
+#define PHP_RUNKIT_SANDBOX_ABORT(objval) \
+{ \
+	tsrm_set_interpreter_context(prior_context); \
+}
+
+#define PHP_RUNKIT_SANDBOX_END(objval) \
+	PHP_RUNKIT_SANDBOX_ABORT(objval) \
+	if (objval->bailed_out_in_eval) { \
+		/* We're actually in bailout mode, but the child's bailout address had to resolve first */ \
+		zend_bailout(); \
+	} \
+}
+
+#define PHP_RUNKIT_SANDBOX_FETCHBOX(zval_p) (php_runkit_sandbox_object*)zend_objects_get_address(zval_p TSRMLS_CC)
+
+int php_runkit_sandbox_array_deep_copy(RUNKIT_53_TSRMLS_ARG(zval **value), int num_args, va_list args, zend_hash_key *hash_key)
+{
+	HashTable *target_hashtable = va_arg(args, HashTable*);
+	zval *copyval;
+
+	MAKE_STD_ZVAL(copyval);
+	*copyval = **value;
+
+	PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(copyval);
+
+	if (hash_key->nKeyLength) {
+		zend_u_hash_quick_update(target_hashtable, hash_key->type == HASH_KEY_IS_UNICODE ? IS_UNICODE : IS_STRING, hash_key->u.string, hash_key->nKeyLength, hash_key->h, &copyval, sizeof(zval*), NULL);
+	} else {
+		zend_hash_index_update(target_hashtable, hash_key->h, &copyval, sizeof(zval*), NULL);
+	}
+
+	return ZEND_HASH_APPLY_KEEP;
+}
+
+/* ******************
+   * Runkit_Sandbox *
+   ****************** */
+
+static HashTable *php_runkit_sandbox_parse_multipath(const char *paths TSRMLS_DC) {
+	HashTable *ht;
+	int len = strlen(paths);
+	char *s, *colon, *pathcopy, tmppath[MAXPATHLEN] = {0};
+
+	if (!len) {
+		return NULL;
+	}
+
+	pathcopy = estrndup(paths, len);
+
+	ALLOC_HASHTABLE(ht);
+	zend_hash_init(ht, 4, NULL, NULL, 0);
+	for (s = pathcopy; (colon = strchr(s, ZEND_PATHS_SEPARATOR)); s = colon + 1) {
+		if (colon > s) {
+			*colon = 0;
+			VCWD_REALPATH(s, tmppath);
+			if (*tmppath) {
+				zend_hash_next_index_insert(ht, tmppath, strlen(tmppath) + 1, NULL);
+			} else {
+				/* s isn't real, leave it in the HashTable anyway
+				 * to avoid making the old setting look like
+				 * it had no values in it and thus allowing privilege elevation.
+				 */
+				zend_hash_next_index_insert(ht, s, (colon - s) + 1, NULL);
+			}
+		}
+	}
+
+	if (*s) {
+		VCWD_REALPATH(s, tmppath);
+		if (*tmppath) {
+			zend_hash_next_index_insert(ht, tmppath, strlen(tmppath) + 1, NULL);
+		} else {
+			/* See above */
+			zend_hash_next_index_insert(ht, s, strlen(s) + 1, NULL);
+		}
+	}
+
+	efree(pathcopy);
+	return ht;
+}
+
+static void php_runkit_sandbox_free_multipath(HashTable *ht TSRMLS_DC) {
+	if (ht) {
+		zend_hash_destroy(ht);
+		FREE_HASHTABLE(ht);
+	}
+}
+
+static char *php_runkit_sandbox_implode_stringht(HashTable *ht TSRMLS_DC) {
+	smart_str s = { 0 };
+	HashPosition pos;
+	char *str;
+
+	for(zend_hash_internal_pointer_reset_ex(ht, &pos);
+	    SUCCESS == zend_hash_get_current_data_ex(ht, (void**)&str, &pos);
+	    zend_hash_move_forward_ex(ht, &pos)) {
+		if (s.len) {
+			smart_str_appendc(&s, ZEND_PATHS_SEPARATOR);
+		}
+		smart_str_appends(&s, str);
+	}
+	smart_str_0(&s);
+	return s.c;
+}
+
+static char *php_runkit_sandbox_tighten_paths(HashTable *oldht, HashTable *newht TSRMLS_DC) {
+	HashPosition newpos;
+	char *newstr;
+
+	if (!oldht && !newht) {
+		return NULL;
+	}
+	if (!oldht) {
+		/* From nothing to something */
+		return php_runkit_sandbox_implode_stringht(newht TSRMLS_CC);
+	}
+	if (!newht) {
+		/* From something to nothing */
+		return NULL;
+	}
+
+	if (zend_hash_num_elements(oldht) == 0) {
+		/* Special edge case
+		 * The parent's setting is ':' or similar.
+		 * Despite looking similar to an empty setting,
+		 * this actually has the opposite meaning.
+		 * '' provides open access to the filesystem
+		 * ':' provides access to none of it.
+		 * THIS DISTINCTION MATTERS. :p
+		 */
+		return NULL;
+	}
+
+	for(zend_hash_internal_pointer_reset_ex(newht, &newpos);
+	    SUCCESS == zend_hash_get_current_data_ex(newht, (void**)&newstr, &newpos);
+	    zend_hash_move_forward_ex(newht, &newpos)) {
+		HashPosition oldpos;
+		char *oldstr;
+		int newstr_len = strlen(newstr);
+
+		for(zend_hash_internal_pointer_reset_ex(oldht, &oldpos);
+		    SUCCESS == zend_hash_get_current_data_ex(oldht, (void**)&oldstr, &oldpos);
+		    zend_hash_move_forward_ex(oldht, &oldpos)) {
+			int oldstr_len = strlen(oldstr);
+			if ((oldstr_len <= newstr_len) &&
+			    !strncmp(oldstr, newstr, oldstr_len) &&
+			    ((oldstr_len == newstr_len) || (newstr[oldstr_len] == DEFAULT_SLASH))) {
+				goto newstr_ok;
+			}
+		}
+		/* Couldn't find an old path that we're constricting, so fail */
+		return NULL;
+newstr_ok: ;
+	}
+
+	return php_runkit_sandbox_implode_stringht(newht TSRMLS_CC);
+}
+
+/* Special .ini options (normally PHP_INI_SYSTEM) which can be overridden within a sandbox in the direction of tighter security
+ *
+ * safe_mode = true
+ *		safe_mode can only be turned on for a sandbox, not off.  Doing so would tend to defeat safe_mode as applied to the calling script
+ * safe_mode_gid = false
+ *		safe_mode_gid can only be turned off as it allows a partial bypass of safe_mode restrictions when on
+ * safe_mode_include_dir = /path/to/includables
+ *		safe_mode_include_dir must be at or below the currently defined include_dir
+ * open_basedir = /path/to/basedir
+ *		open_basedir must be at or below the currently defined basedir for the same reason that safe_mode can only be turned on
+ * allow_url_fopen = false
+ *		allow_url_fopen may only be turned off for a sandbox, not on.   Once again, don't castrate the existing restrictions
+ * allow_url_include = false
+ *		allow_url_include may only be turned off for a sandbox, not on.   Once again, don't castrate the existing restrictions
+ * disable_functions = coma_separated,list_of,additional_functions
+ *		ADDITIONAL functions, on top of already disabled functions to disable
+ * disable_classes = coma_separated,list_of,additional_classes
+ *		ADDITIONAL classes, on top of already disabled classes to disable
+ * runkit.superglobals = coma_separated,list_of,superglobals
+ *		ADDITIONAL superglobals to define in the subinterpreter
+ * runkit.internal_override = false
+ *		runkit.internal_override may be disabled (but not re-enabled) within sandboxes
+ */
+static inline void php_runkit_sandbox_ini_override(php_runkit_sandbox_object *objval, HashTable *options TSRMLS_DC)
+{
+	zend_bool allow_url_fopen;
+#ifdef ZEND_ENGINE_2_2
+	zend_bool allow_url_include;
+#endif
+	HashTable *open_basedirs = NULL;
+	zval **tmpzval;
+
+	/* Collect up parent values */
+	tsrm_set_interpreter_context(objval->parent_context);
+	{
+		/* Check current settings in parent context */
+		TSRMLS_FETCH_FROM_CTX(objval->parent_context);
+		if (PG(open_basedir) && *PG(open_basedir)) {
+			open_basedirs = php_runkit_sandbox_parse_multipath(PG(open_basedir) TSRMLS_CC);
+		}
+		allow_url_fopen = PG(allow_url_fopen);
+#ifdef ZEND_ENGINE_2_2
+		allow_url_include = PG(allow_url_include);
+#endif
+	}
+	tsrm_set_interpreter_context(objval->context);
+
+	/* open_basedir goes deeper only */
+	if ((tmpzval = zend_hash_str_find(options, "open_basedir", sizeof("open_basedir"), (void*)&tmpzval)) != NULL &&
+		Z_TYPE_PP(tmpzval) == IS_STRING) {
+
+		if (!open_basedirs) {
+			/* simplest case -- no open basedir existed yet */
+			zend_alter_ini_entry("open_basedir", sizeof("open_basedir"), Z_STRVAL_PP(tmpzval), Z_STRLEN_PP(tmpzval), PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+			goto child_open_basedir_set;
+		} else {
+			HashTable *new_open_basedirs = php_runkit_sandbox_parse_multipath(Z_STRVAL_PP(tmpzval) TSRMLS_CC);			char *new_open_basedir = php_runkit_sandbox_tighten_paths(open_basedirs, new_open_basedirs TSRMLS_CC);
+			php_runkit_sandbox_free_multipath(new_open_basedirs TSRMLS_CC);
+
+			if (new_open_basedir) {
+				/* Tightening up of existing security level */
+				zend_alter_ini_entry("open_basedir", sizeof("open_basedir"), new_open_basedir, strlen(new_open_basedir), PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+				efree(new_open_basedir);
+				goto child_open_basedir_set;
+			}
+		}
+	}
+	if (open_basedirs) {
+		/* Inherit parent's setting by default which may be PHP_INI_USER level setting */
+		char *parent_open_basedir = php_runkit_sandbox_implode_stringht(open_basedirs TSRMLS_CC);
+		zend_alter_ini_entry("open_basedir", sizeof("open_basedir"), parent_open_basedir, strlen(parent_open_basedir), PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+		efree(parent_open_basedir);
+	}
+child_open_basedir_set:
+
+	/* allow_url_fopen goes off only */
+	if (allow_url_fopen &&
+		(tmpzval = zend_hash_str_find(options, "allow_url_fopen", sizeof("allow_url_fopen"), (void*)&tmpzval)) != NULL) {
+		zval copyval = **tmpzval;
+
+		zval_copy_ctor(&copyval);
+		convert_to_boolean(&copyval);
+
+		if (!Z_BVAL(copyval)) {
+			zend_alter_ini_entry("allow_url_fopen", sizeof("allow_url_fopen"), "0", 1, PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+		}
+	}
+
+	/* Can only disable additional functions */
+	if ((tmpzval = zend_hash_str_find(options, "disable_functions", sizeof("disable_functions"), (void*)&tmpzval)) != NULL &&
+		Z_TYPE_PP(tmpzval) == IS_STRING) {
+		/* NOTE: disable_functions doesn't prevent $obj->function_name, it only blocks code inside $obj->eval() statements
+		 * This could be brought into consistency, but I actually think it's okay to leave those functions available to calling script
+		 */
+		/* This buffer needs to be around when the error message occurs since the underlying implementation in Zend expects it to be */
+		int disable_functions_len = Z_STRLEN_PP(tmpzval);
+		char *p, *s;
+
+		objval->disable_functions = estrndup(Z_STRVAL_PP(tmpzval), disable_functions_len);
+
+		s = objval->disable_functions;
+		while ((p = strchr(s, ','))) {
+			*p = '\0';
+			zend_disable_function(s, p - s TSRMLS_CC);
+			s = p + 1;
+		}
+		zend_disable_function(s, strlen(s) TSRMLS_CC);
+	}
+
+	/* Can only disable additional classes */
+	if ((tmpzval = zend_hash_str_find(options, "disable_classes", sizeof("disable_classes"), (void*)&tmpzval)) != NULL &&
+		Z_TYPE_PP(tmpzval) == IS_STRING) {
+		/* This buffer needs to be around when the error message occurs since the underlying implementation in Zend expects it to be */
+		int disable_classes_len = Z_STRLEN_PP(tmpzval);
+		char *p, *s;
+
+		objval->disable_classes = estrndup(Z_STRVAL_PP(tmpzval), disable_classes_len);
+
+		s = objval->disable_classes;
+		while ((p = strchr(s, ','))) {
+			*p = '\0';
+			zend_disable_class(s, p - s TSRMLS_CC);
+			s = p + 1;
+		}
+		zend_disable_class(s, strlen(s) TSRMLS_CC);
+	}
+
+	/* Additional superglobals to define */
+	if ((tmpzval = zend_hash_str_find(options, "runkit.superglobal", sizeof("runkit.superglobal"), (void*)&tmpzval)) != NULL &&
+		Z_TYPE_PP(tmpzval) == IS_STRING) {
+		char *p, *s = Z_STRVAL_PP(tmpzval);
+		int len;
+
+		while ((p = strchr(s, ','))) {
+			if (p - s) {
+				*p = '\0';
+				zend_register_auto_global(zend_string_init(s, p - s, 0), 0, NULL TSRMLS_CC);
+				zend_activate_auto_globals(TSRMLS_C);
+				*p = ',';
+			}
+			s = p + 1;
+		}
+		zend_register_auto_global(zend_string_init(s, strlen(s), 0), 0, NULL TSRMLS_CC);
+	}
+
+	/* May only turn off */
+	if (zend_hash_str_find(options, "runkit.internal_override", sizeof("runkit.internal_override"), (void*)&tmpzval) == SUCCESS) {
+		zval copyval = **tmpzval;
+
+		zval_copy_ctor(&copyval);
+		convert_to_boolean(&copyval);
+
+		if (!Z_BVAL(copyval)) {
+			zend_alter_ini_entry("runkit.internal_override", sizeof("runkit.internal_override"), "0", 1, PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+		}
+	}
+
+#ifdef ZEND_ENGINE_2_2
+	/* May only turn off */
+	if (allow_url_include &&
+	    ((tmpzval = zend_hash_str_find(options, "allow_url_include", sizeof("allow_url_include"), (void**)&tmpzval)) != NULL) &&
+	    !zend_is_true(*tmpzval)) {
+		zend_alter_ini_entry("allow_url_include", sizeof("allow_url_include"), "0", 1, PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+	}
+#endif
+
+	if (open_basedirs) {
+		tsrm_set_interpreter_context(objval->parent_context);
+    php_runkit_sandbox_free_multipath(open_basedirs TSRMLS_CC);
+		tsrm_set_interpreter_context(objval->context);
+	}
+}
+/* }}} */
+
+/* {{{ proto void Runkit_Sandbox::__construct(array options)
+ * Options: see php_runkit_sandbox_ini_override()
+ */
+PHP_METHOD(Runkit_Sandbox,__construct)
+{
+	php_runkit_sandbox_object *objval = PHP_RUNKIT_SANDBOX_FETCHBOX(this_ptr);
+	zval *options = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|a", &options) == FAILURE) {
+		RETURN_NULL();
+	}
+
+	objval->context = tsrm_new_interpreter_context();
+	objval->disable_functions = NULL;
+	objval->disable_classes = NULL;
+	objval->output_handler = NULL;
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		objval->parent_context = prior_context;
+
+		zend_alter_ini_entry("implicit_flush", sizeof("implicit_flush") , "1", 1, PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+		zend_alter_ini_entry("max_execution_time", sizeof("max_execution_time") , "0", 1, PHP_INI_SYSTEM, PHP_INI_STAGE_ACTIVATE);
+		if (options) {
+			/* Override a select subset of .ini options for increased restriction in the sandbox */
+			php_runkit_sandbox_ini_override(objval, Z_ARRVAL_P(options) TSRMLS_CC);
+		}
+
+		SG(headers_sent) = 1;
+		SG(request_info).no_headers = 1;
+		SG(options) = SAPI_OPTION_NO_CHDIR;
+		RUNKIT_G(current_sandbox) = objval; /* Needs to be set before RINIT */
+		php_request_startup(TSRMLS_C);
+		RUNKIT_G(current_sandbox) = objval; /* But gets reset during RINIT -- Bad design on my part */
+		PG(during_request_startup) = 0;
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	/* Prime the sandbox to be played in */
+	objval->active = 1;
+
+	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox::__call(mixed function_name, array args)
+	Call User Function */
+PHP_METHOD(Runkit_Sandbox,__call)
+{
+	zval *func_name, *args, *retval = NULL;
+	php_runkit_sandbox_object *objval;
+	int bailed_out = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "za", &func_name, &args) == FAILURE) {
+		RETURN_NULL();
+	}
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(this_ptr);
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		RETURN_NULL();
+	}
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+	{
+		char *name = NULL;
+
+		zend_first_try {
+			if (!RUNKIT_IS_CALLABLE(func_name, IS_CALLABLE_CHECK_NO_ACCESS, &name)) {
+				php_error_docref1(NULL TSRMLS_CC, name, E_WARNING, "Function not defined");
+				if (name) {
+					efree(name);
+				}
+				PHP_RUNKIT_SANDBOX_ABORT(objval)
+				RETURN_FALSE;
+			}
+
+			php_runkit_sandbox_call_int(func_name, &name, &retval, args, return_value, prior_context TSRMLS_CC);
+		} zend_catch {
+			bailed_out = 1;
+			objval->active = 0;
+		} zend_end_try();
+	}
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	if (bailed_out) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed calling sandbox function");
+		RETURN_FALSE;
+	}
+
+	PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(return_value);
+
+	if (retval) {
+		PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		(void)(TSRMLS_C);
+		zval_ptr_dtor(&retval);
+		PHP_RUNKIT_SANDBOX_END(objval)
+	}
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_include_or_eval
+ */
+static void php_runkit_sandbox_include_or_eval(INTERNAL_FUNCTION_PARAMETERS, int type, int once)
+{
+	php_runkit_sandbox_object *objval;
+	zval *zcode;
+	int bailed_out = 0;
+	zval *retval = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zcode) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	convert_to_string(zcode);
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(this_ptr);
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		RETURN_NULL();
+	}
+
+	RETVAL_NULL();
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		zend_first_try {
+			zend_op_array *op_array = NULL;
+			int already_included = 0;
+
+			op_array = php_runkit_sandbox_include_or_eval_int(return_value, zcode, type, once, &already_included TSRMLS_CC);
+
+			if (op_array) {
+				EG(return_value_ptr_ptr) = &retval;
+				EG(active_op_array) = op_array;
+
+				zend_execute(op_array TSRMLS_CC);
+
+				if (retval) {
+					*return_value = *retval;
+				} else {
+					RETVAL_TRUE;
+				}
+
+				destroy_op_array(op_array TSRMLS_CC);
+				efree(op_array);
+			} else if ((type != ZEND_INCLUDE) && !already_included) {
+				/* include can fail to parse peacefully,
+				 * require and eval should die on failure
+				 */
+				objval->active = 0;
+				bailed_out = 1;
+			}
+		} zend_catch {
+            /* It's impossible to know what caused the failure, just deactive the sandbox now */
+			objval->active = 0;
+			bailed_out = 1;
+		} zend_end_try();
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	if (bailed_out) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error executing sandbox code");
+		RETURN_FALSE;
+	}
+
+	PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(return_value);
+
+	/* Don't confuse the memory manager */
+	if (retval) {
+		PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		(void)(TSRMLS_C);
+		zval_ptr_dtor(&retval);
+		PHP_RUNKIT_SANDBOX_END(objval)
+	}
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox::eval(string phpcode)
+	Evaluate php code within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox,eval)
+{
+	php_runkit_sandbox_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_EVAL, 0);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox::include(string filename)
+	Evaluate php code from a file within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox,include)
+{
+	php_runkit_sandbox_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_INCLUDE, 0);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox::include_once(string filename)
+	Evaluate php code from a file within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox,include_once)
+{
+	php_runkit_sandbox_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_INCLUDE, 1);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox::require(string filename)
+	Evaluate php code from a file within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox,require)
+{
+	php_runkit_sandbox_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_REQUIRE, 0);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox::require_once(string filename)
+	Evaluate php code from a file within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox,require_once)
+{
+	php_runkit_sandbox_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_REQUIRE, 1);
+}
+/* }}} */
+
+/* {{{ proto null Runkit_Sandbox::echo(mixed var[, mixed var[, ... ]])
+	Echo through the sandbox
+	The only thing which distinguished this from a non-sandboxed echo
+	is that content gets processed through the sandbox's output_handler (if present) */
+PHP_METHOD(Runkit_Sandbox,echo)
+{
+	php_runkit_sandbox_object *objval;
+	zval ***argv;
+	int i, argc = ZEND_NUM_ARGS();
+
+	argv = emalloc(sizeof(zval**) * argc);
+	if (zend_get_parameters_array_ex(argc, argv) == FAILURE) {
+		efree(argv);
+		/* Big problems... */
+		RETURN_NULL();
+	}
+
+	for(i = 0; i < argc; i++) {
+		/* Prepare for output */
+		convert_to_string(*(argv[i]));
+	}
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(this_ptr);
+	if (!objval->active) {
+		efree(argv);
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		RETURN_NULL();
+	}
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		zend_try {
+			for(i = 0; i < argc; i++) {
+				PHPWRITE(Z_STRVAL_PP(argv[i]),Z_STRLEN_PP(argv[i]));
+			}
+		} zend_catch {
+			objval->active = 0;
+		} zend_end_try();
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	efree(argv);
+
+	RETURN_NULL();
+}
+/* }}} */
+
+/* {{{ proto bool Runkit_Sandbox::print(mixed var)
+	Echo through the sandbox
+	The only thing which distinguished this from a non-sandboxed echo
+	is that content gets processed through the sandbox's output_handler (if present) */
+PHP_METHOD(Runkit_Sandbox,print)
+{
+	php_runkit_sandbox_object *objval;
+	char *str;
+	int len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &len) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(this_ptr);
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		RETURN_NULL();
+	}
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		zend_try {
+			PHPWRITE(str,len);
+		} zend_catch {
+			objval->active = 0;
+		} zend_end_try();
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	RETURN_BOOL(len > 1 || (len == 1 && str[0] != '0'));
+}
+/* }}} */
+
+/* {{{ proto void Runkit_Sandbox::die(mixed message)
+	MALIAS(exit)
+	Terminate a sandbox instance */
+PHP_METHOD(Runkit_Sandbox,die)
+{
+	php_runkit_sandbox_object *objval;
+	zval *message = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z", &message) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	RETVAL_NULL();
+
+	if (message && Z_TYPE_P(message) != IS_LONG) {
+		convert_to_string(message);
+	}
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(this_ptr);
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		return;
+	}
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		zend_try {
+			if (message) {
+				if (Z_TYPE_P(message) == IS_LONG) {
+					EG(exit_status) = Z_LVAL_P(message);
+				} else {
+					PHPWRITE(Z_STRVAL_P(message), Z_STRLEN_P(message));
+				}
+			}
+			zend_bailout();
+		} zend_catch {
+			/* goes without saying doesn't it? */
+			objval->active = 0;
+		} zend_end_try();
+	PHP_RUNKIT_SANDBOX_END(objval)
+}
+/* }}} */
+
+/* *********************
+   * Property Handlers *
+   ********************* */
+
+/* {{{ php_runkit_sandbox_read_property
+	read_property handler */
+static zval *php_runkit_sandbox_read_property(zval *object, zval *member, int type
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval = PHP_RUNKIT_SANDBOX_FETCHBOX(object);
+	zval tmp_member;
+	zval retval;
+	int prop_found = 0;
+
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		return EG(uninitialized_zval_ptr);
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, tmp_member);
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		zend_try {
+			zval **value;
+
+			if ((value = zend_hash_str_find(&EG(symbol_table), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void*)&value)) != NULL) {
+				retval = **value;
+				prop_found = 1;
+			}
+		} zend_catch {
+			/* Almost certainly impossible... */
+			objval->active = 0;
+		} zend_end_try();
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	if (member == &tmp_member) {
+		zval_dtor(member);
+	}
+
+	return php_runkit_sandbox_return_property_value(prop_found, &retval TSRMLS_CC);
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_write_property
+	write_property handler */
+static void php_runkit_sandbox_write_property(zval *object, zval *member, zval *value
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval = PHP_RUNKIT_SANDBOX_FETCHBOX(object);
+	zval tmp_member;
+
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		return;
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, tmp_member);
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		zend_try {
+			zval *copyval;
+
+			MAKE_STD_ZVAL(copyval);
+			*copyval = *value;
+			PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(copyval);
+			ZEND_SET_SYMBOL(&EG(symbol_table), Z_STRVAL_P(member), copyval);
+		} zend_catch {
+			/* An emalloc() could bailout */
+			objval->active = 0;
+		} zend_end_try();
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	if (member == &tmp_member) {
+		zval_dtor(member);
+	}
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_has_property
+	has_property handler */
+static int php_runkit_sandbox_has_property(zval *object, zval *member, int has_set_exists
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_object* objval = PHP_RUNKIT_SANDBOX_FETCHBOX(object);
+	zval member_copy;
+	int result = 0;
+
+	if (!objval) {
+		return 0;
+	}
+	/* It's okay to read the symbol table post bailout */
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		php_runkit_sandbox_has_property_int(has_set_exists, member TSRMLS_CC);
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	if (member == &member_copy) {
+		zval_dtor(member);
+	}
+
+	return result;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_unset_property
+	unset_property handler */
+static void php_runkit_sandbox_unset_property(zval *object, zval *member
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval;
+	zval member_copy;
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(object);
+	if (!objval) {
+		return;
+	}
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		return;
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
+
+	PHP_RUNKIT_SANDBOX_BEGIN(objval)
+		zend_hash_del(&EG(symbol_table), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1);
+	PHP_RUNKIT_SANDBOX_END(objval)
+
+	if (member == &member_copy) {
+		zval_dtor(member);
+	}
+}
+/* }}} */
+
+/* **************
+   * SAPI Wedge *
+   ************** */
+
+static sapi_module_struct php_runkit_sandbox_original_sapi;
+
+/* {{{ php_runkit_sandbox_sapi_ub_write
+ * Wrap the caller's output handler with a mechanism for switching contexts
+ */
+static int php_runkit_sandbox_sapi_ub_write(const char *str, uint str_length TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval = RUNKIT_G(current_sandbox);
+	int bytes_written;
+
+	if (!str_length) {
+		return 0;
+	}
+
+	if (!objval) {
+		/* Not in a sandbox -- Use genuine sapi.ub_write handler */
+		if (php_runkit_sandbox_original_sapi.ub_write) {
+			return php_runkit_sandbox_original_sapi.ub_write(str, str_length TSRMLS_CC);
+		} else {
+			/* Ignore data, no real SAPI handler to pass it to */
+			return str_length;
+		}
+	}
+
+	tsrm_set_interpreter_context(objval->parent_context);
+	{
+		zval **output_buffer[1], *bufcopy, *retval = NULL;
+		TSRMLS_FETCH();
+
+		if (!objval->output_handler ||
+			!RUNKIT_IS_CALLABLE(objval->output_handler, IS_CALLABLE_CHECK_NO_ACCESS, NULL)) {
+			/* No hander, or invalid handler, pass up the line... */
+			bytes_written = PHPWRITE(str, str_length);
+
+			tsrm_set_interpreter_context(objval->context);
+
+			return bytes_written;
+		}
+
+		MAKE_STD_ZVAL(bufcopy);
+		ZVAL_STRINGL(bufcopy, (char*)str, str_length, 1);
+		output_buffer[0] = &bufcopy;
+
+		if (call_user_function_ex(EG(function_table), NULL, objval->output_handler, &retval, 1, output_buffer, 0, NULL TSRMLS_CC) == SUCCESS) {
+			if (retval) {
+				if (Z_TYPE_P(retval) != IS_NULL) {
+					convert_to_string(retval);
+					PHPWRITE(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
+				}
+				zval_ptr_dtor(&retval);
+				bytes_written = str_length;
+			} else {
+				bytes_written = 0;
+			}
+		} else {
+			php_error_docref("runkit.sandbox" TSRMLS_CC, E_WARNING, "Unable to call output buffer callback");
+			bytes_written = 0;
+		}
+
+		if (bufcopy) {
+			zval_ptr_dtor(&bufcopy);
+		}
+	}
+	tsrm_set_interpreter_context(objval->context);
+
+	return bytes_written;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_flush
+ */
+static void php_runkit_sandbox_sapi_flush(void *server_context)
+{
+	php_runkit_sandbox_object *objval;
+	TSRMLS_FETCH();
+
+	objval = RUNKIT_G(current_sandbox);
+
+	if (!objval) {
+		/* Not in a sandbox -- Use genuine sapi.flush handler */
+		if (php_runkit_sandbox_original_sapi.flush) {
+			php_runkit_sandbox_original_sapi.flush(server_context);
+		}
+		return;
+	}
+
+	tsrm_set_interpreter_context(objval->parent_context);
+	{
+		zval *retval = NULL, **args[1];
+		TSRMLS_FETCH();
+
+		if (!objval->output_handler ||
+			!RUNKIT_IS_CALLABLE(objval->output_handler, IS_CALLABLE_CHECK_NO_ACCESS, NULL)) {
+			/* No hander, or invalid handler, pass up the line... */
+			if (php_runkit_sandbox_original_sapi.flush) {
+				php_runkit_sandbox_original_sapi.flush(server_context);
+			}
+			tsrm_set_interpreter_context(objval->context);
+			return;
+		}
+
+		args[0] = &EG(uninitialized_zval_ptr);
+
+		if (call_user_function_ex(EG(function_table), NULL, objval->output_handler, &retval, 1, args, 0, NULL TSRMLS_CC) == SUCCESS) {
+			if (retval) {
+				if (Z_TYPE_P(retval) != IS_NULL) {
+					convert_to_string(retval);
+					PHPWRITE(Z_STRVAL_P(retval), Z_STRLEN_P(retval));
+				}
+				zval_ptr_dtor(&retval);
+			}
+		} else {
+			php_error_docref("runkit.sandbox" TSRMLS_CC, E_WARNING, "Unable to call output buffer callback");
+		}
+	}
+	tsrm_set_interpreter_context(objval->context);
+
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_get_stat
+ */
+static struct stat *php_runkit_sandbox_sapi_get_stat(TSRMLS_D)
+{
+	php_runkit_sandbox_object *objval = RUNKIT_G(current_sandbox);
+	struct stat *ret;
+
+	if (objval) {
+		tsrm_set_interpreter_context(objval->parent_context);
+		{
+			TSRMLS_FETCH();
+
+			ret = php_runkit_sandbox_original_sapi.get_stat(TSRMLS_C);
+		}
+		tsrm_set_interpreter_context(objval->context);
+	} else {
+		ret = php_runkit_sandbox_original_sapi.get_stat(TSRMLS_C);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_getenv
+ */
+static char *php_runkit_sandbox_sapi_getenv(char *name, size_t name_len TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval = RUNKIT_G(current_sandbox);
+	char *ret;
+
+	if (objval) {
+		tsrm_set_interpreter_context(objval->parent_context);
+		{
+			TSRMLS_FETCH();
+
+			ret = php_runkit_sandbox_original_sapi.getenv(name, name_len TSRMLS_CC);
+		}
+		tsrm_set_interpreter_context(objval->context);
+	} else {
+		ret = php_runkit_sandbox_original_sapi.getenv(name, name_len TSRMLS_CC);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_sapi_error
+ */
+static void php_runkit_sandbox_sapi_sapi_error(int type, const char *error_msg, ...)
+{
+	char *message;
+	va_list args;
+	php_runkit_sandbox_object *objval;
+	TSRMLS_FETCH();
+
+	objval = RUNKIT_G(current_sandbox);
+
+	va_start(args, error_msg);
+	vspprintf(&message, 0, error_msg, args);
+	va_end(args);
+
+	if (objval) {
+		tsrm_set_interpreter_context(objval->parent_context);
+		{
+			TSRMLS_FETCH();
+			(void)(TSRMLS_C);
+
+			php_runkit_sandbox_original_sapi.sapi_error(type, "%s", message);
+		}
+	} else {
+		php_runkit_sandbox_original_sapi.sapi_error(type, "%s", message);
+	}
+
+	efree(message);
+
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_header_handler
+ * Ignore headers when in a subrequest
+ */
+static int php_runkit_sandbox_sapi_header_handler(sapi_header_struct *sapi_header,
+                                                  sapi_header_op_enum op,
+                                                  sapi_headers_struct *sapi_headers TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.header_handler(sapi_header,
+                                                               op,
+                                                               sapi_headers TSRMLS_CC);
+	}
+
+	/* Otherwise ignore headers -- TODO: Provide a way for the calling scope to receive these a la output handler */
+	return SAPI_HEADER_ADD;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_send_headers
+ * Pretend to send headers
+ */
+static int php_runkit_sandbox_sapi_send_headers(sapi_headers_struct *sapi_headers TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.send_headers(sapi_headers TSRMLS_CC);
+	}
+
+	/* Do nothing */
+	return SAPI_HEADER_SENT_SUCCESSFULLY;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_send_header
+ * Pretend to send header
+ */
+static void php_runkit_sandbox_sapi_send_header(sapi_header_struct *sapi_header, void *server_context TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		php_runkit_sandbox_sapi_send_header(sapi_header, server_context TSRMLS_CC);
+		return;
+	}
+
+	/* Do nothing */
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_read_post
+ */
+static int php_runkit_sandbox_sapi_read_post(char *buffer, uint count_bytes TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.read_post(buffer, count_bytes TSRMLS_CC);
+	}
+
+	/* return nothing */
+	return 0;
+}
+/* }}} */
+
+/* {{( php_runkit_sandbox_sapi_read_cookies
+ * Pretend to read cookies
+ */
+static char *php_runkit_sandbox_sapi_read_cookies(TSRMLS_D)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.read_cookies(TSRMLS_C);
+	}
+
+	/* Do nothing */
+	return NULL;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_register_server_variables
+ */
+static void php_runkit_sandbox_sapi_register_server_variables(zval *track_vars_array TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		php_runkit_sandbox_original_sapi.register_server_variables(track_vars_array TSRMLS_CC);
+	}
+
+	/* Do nothing */
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_log_message
+ */
+static void php_runkit_sandbox_sapi_log_message(char *message
+	TSRMLS_DC
+	)
+{
+
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		php_runkit_sandbox_original_sapi.log_message(message
+								TSRMLS_CC
+			);
+		return;
+	}
+
+	/* Do nothing */
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_get_request_time
+ */
+static double php_runkit_sandbox_sapi_get_request_time(TSRMLS_D)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.get_request_time(TSRMLS_C);
+	}
+
+	/* Parrot what main/SAPI.c does */
+	if (!SG(global_request_time)) {
+		SG(global_request_time) = time(0);
+	}
+	return SG(global_request_time);
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_block_interruptions
+ */
+static void php_runkit_sandbox_sapi_block_interruptions(void)
+{
+	TSRMLS_FETCH();
+
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		php_runkit_sandbox_original_sapi.block_interruptions();
+		return;
+	}
+
+	/* Do nothing */
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_unblock_interruptions
+ */
+static void php_runkit_sandbox_sapi_unblock_interruptions(void)
+{
+	TSRMLS_FETCH();
+
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		php_runkit_sandbox_original_sapi.unblock_interruptions();
+		return;
+	}
+
+	/* Do nothing */
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_default_post_reader
+ */
+static void php_runkit_sandbox_sapi_default_post_reader(TSRMLS_D)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		php_runkit_sandbox_original_sapi.default_post_reader(TSRMLS_C);
+		return;
+	}
+
+	/* Do nothing */
+	return;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_get_fd
+ */
+static int php_runkit_sandbox_sapi_get_fd(int *fd TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.get_fd(fd TSRMLS_CC);
+	}
+
+	/* Do nothing */
+	return FAILURE;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_force_http_10
+ */
+static int php_runkit_sandbox_sapi_force_http_10(TSRMLS_D)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.force_http_10(TSRMLS_C);
+	}
+
+	/* Do nothing */
+	return FAILURE;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_get_target_uid
+ */
+static int php_runkit_sandbox_sapi_get_target_uid(uid_t *uid TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.get_target_uid(uid TSRMLS_CC);
+	}
+
+	/* Do nothing */
+	return FAILURE;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_get_target_gid
+ */
+static int php_runkit_sandbox_sapi_get_target_gid(uid_t *gid TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.get_target_gid(gid TSRMLS_CC);
+	}
+
+	/* Do nothing */
+	return FAILURE;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_sapi_input_filter
+ */
+static unsigned int php_runkit_sandbox_sapi_input_filter(int arg, char *var, char **val, unsigned int val_len, unsigned int *new_val_len TSRMLS_DC)
+{
+	if (!RUNKIT_G(current_sandbox)) {
+		/* Not in a sandbox use SAPI's actual handler */
+		return php_runkit_sandbox_original_sapi.input_filter(arg, var, val, val_len, new_val_len TSRMLS_CC);
+	}
+
+	/* Parrot php_default_input_filter */
+	if (new_val_len) {
+		*new_val_len = val_len;
+	}
+
+	return 1;
+}
+/* }}} */
+
+/* ********************
+   * Output Buffering *
+   ******************** */
+
+/* {{{ proto mixed runkit_sandbox_output_handler(Runkit_Sandbox sandbox[, mixed callback])
+	Returns the output handler which was active prior to calling this method,
+	or false if no output handler is active
+
+	If no callback is passed, the current output handler is not changed
+	If a non-true output handler is passed(NULL,false,0,0.0,'',array()), output handling is turned off
+
+	If an error occurs (such as callback is not callable), NULL is returned
+
+	DEPRECATED!  THIS WILL BE REMOVED PRIOR TO THE RELEASE OF RUNKIT VERSION 1.0!!! */
+PHP_FUNCTION(runkit_sandbox_output_handler)
+{
+	zval *sandbox;
+	zval *callback = NULL;
+	php_runkit_sandbox_object *objval;
+	char *name = NULL;
+	int callback_is_true = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "O|z", &sandbox, php_runkit_sandbox_class_entry, &callback) == FAILURE) {
+		RETURN_NULL();
+	}
+	php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Use of runkit_sandbox_output_handler() is deprecated.  Use $sandbox['output_handler'] instead.");
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(sandbox);
+	if (!objval->active) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Current sandbox is no longer active");
+		RETURN_NULL();
+	}
+
+	if (callback) {
+		zval callback_copy = *callback;
+
+		zval_copy_ctor(&callback_copy);
+		callback_copy.RUNKIT_IS_REF = 0;
+		callback_copy.RUNKIT_REFCOUNT = 1;
+		callback_is_true = zval_is_true(&callback_copy);
+		zval_dtor(&callback_copy);
+	}
+
+	if (callback && callback_is_true &&
+		!RUNKIT_IS_CALLABLE(callback, IS_CALLABLE_CHECK_NO_ACCESS, &name)) {
+		php_error_docref1(NULL TSRMLS_CC, name, E_WARNING, "Second argument (%s) is expected to be a valid callback", name);
+		if (name) {
+			efree(name);
+		}
+		RETURN_FALSE;
+	}
+	if (name) {
+		efree(name);
+	}
+
+	if (objval->output_handler && return_value_used) {
+		*return_value = *objval->output_handler;
+		zval_copy_ctor(return_value);
+		return_value->RUNKIT_REFCOUNT = 1;
+		return_value->RUNKIT_IS_REF = 0;
+	} else {
+		RETVAL_FALSE;
+	}
+
+	if (!callback) {
+		return;
+	}
+
+	if (objval->output_handler) {
+		zval_ptr_dtor(&objval->output_handler);
+		objval->output_handler = NULL;
+	}
+
+	if (callback && callback_is_true) {
+		zval *cb = callback;
+		if (callback->RUNKIT_IS_REF) {
+			MAKE_STD_ZVAL(cb);
+			*cb = *callback;
+			zval_copy_ctor(cb);
+			cb->RUNKIT_REFCOUNT = 0;
+			cb->RUNKIT_IS_REF = 0;
+		}
+		cb->RUNKIT_REFCOUNT++;
+		objval->output_handler = cb;
+	}
+}
+/* }}} */
+
+/* **********************
+   * Dimension Handlers *
+   ********************** */
+
+#define PHP_RUNKIT_SANDBOX_SETTING_ENTRY(name, get, set)	{ #name, sizeof(#name) - 1, (zval *(*)(php_runkit_sandbox_object *objval TSRMLS_DC)) get, (int (*)(php_runkit_sandbox_object *objval, zval *value TSRMLS_DC)) set },
+#define PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(name)			{ #name, sizeof(#name) - 1, (zval *(*)(php_runkit_sandbox_object *objval TSRMLS_DC)) php_runkit_sandbox_ ## name ## _getter, (int (*)(php_runkit_sandbox_object *objval, zval *value TSRMLS_DC)) php_runkit_sandbox_ ## name ## _setter },
+#define PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RD(name)	{ #name, sizeof(#name) - 1, (zval *(*)(php_runkit_sandbox_object *objval TSRMLS_DC)) php_runkit_sandbox_ ## name ## _getter, NULL },
+#define PHP_RUNKIT_SANDBOX_SETTING_ENTRY_WR(name)	{ #name, sizeof(#name) - 1, NULL, (int (*)(php_runkit_sandbox_object *objval, zval *value TSRMLS_DC)) php_runkit_sandbox_ ## name ## _setter },
+#define PHP_RUNKIT_SANDBOX_SETTING_SETTER(name)		static void php_runkit_sandbox_ ## name ## _setter(php_runkit_sandbox_object *objval, zval *value TSRMLS_DC)
+#define PHP_RUNKIT_SANDBOX_SETTING_GETTER(name)		static zval* php_runkit_sandbox_ ## name ## _getter(php_runkit_sandbox_object *objval TSRMLS_DC)
+
+#define PHP_RUNKIT_SANDBOX_SETTING_BOOL_WR(name) \
+PHP_RUNKIT_SANDBOX_SETTING_SETTER(name) \
+{ \
+	zval copyval = *value; \
+\
+	zval_copy_ctor(&copyval); \
+	convert_to_boolean(&copyval); \
+	objval->name = Z_BVAL(copyval) ? 1 : 0; \
+}
+#define PHP_RUNKIT_SANDBOX_SETTING_BOOL_RD(name) \
+PHP_RUNKIT_SANDBOX_SETTING_GETTER(name) \
+{ \
+	zval *retval; \
+\
+	ALLOC_ZVAL(retval); \
+	Z_TYPE_P(retval) = IS_BOOL; \
+	Z_LVAL_P(retval) = objval->name; \
+	retval->RUNKIT_REFCOUNT = 0; \
+	retval->RUNKIT_IS_REF = 0; \
+\
+	return retval; \
+}
+#define PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(name) \
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_WR(name) \
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RD(name)
+
+PHP_RUNKIT_SANDBOX_SETTING_GETTER(output_handler)
+{
+	if (!objval->output_handler) {
+		return EG(uninitialized_zval_ptr);
+	}
+
+	return objval->output_handler;
+}
+
+PHP_RUNKIT_SANDBOX_SETTING_SETTER(output_handler)
+{
+	if (!RUNKIT_IS_CALLABLE(value, IS_CALLABLE_CHECK_NO_ACCESS, NULL)) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "output_handler is not a valid callback is expected to be a valid callback");
+	}
+
+	if (objval->output_handler) {
+		zval_ptr_dtor(&objval->output_handler);
+	}
+
+	value->RUNKIT_REFCOUNT++;
+	objval->output_handler = value;
+}
+
+PHP_RUNKIT_SANDBOX_SETTING_GETTER(parent_scope)
+{
+	zval *retval;
+
+	MAKE_STD_ZVAL(retval);
+	if (objval->parent_scope == 0 &&
+		objval->parent_scope_name) {
+		ZVAL_STRINGL(retval, objval->parent_scope_name, objval->parent_scope_namelen, 1);
+	} else {
+		ZVAL_LONG(retval, objval->parent_scope);
+	}
+	retval->RUNKIT_REFCOUNT = 0;
+
+	return retval;
+}
+
+PHP_RUNKIT_SANDBOX_SETTING_SETTER(parent_scope)
+{
+	zval copyval = *value;
+
+	if (Z_TYPE_P(value) == IS_STRING) {
+		/* Variable in global symbol_table */
+		objval->parent_scope = 0;
+		if (objval->parent_scope_name) {
+			efree(objval->parent_scope_name);
+		}
+		objval->parent_scope_name = estrndup(Z_STRVAL_P(value), Z_STRLEN_P(value) + 1);
+		objval->parent_scope_namelen = Z_STRLEN_P(value);
+
+		return;
+	}
+
+	if (objval->parent_scope_name) {
+		efree(objval->parent_scope_name);
+		objval->parent_scope_name = NULL;
+	}
+	objval->parent_scope_namelen = 0;
+
+	zval_copy_ctor(&copyval);
+	convert_to_long(&copyval);
+	if (Z_LVAL(copyval) < 0) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Invalid scope, assuming 0");
+		objval->parent_scope = 0;
+		return;
+	}
+
+	/* Assumes that such a deep scope *will* exist when a var is resolved
+	 * If the scopes don't go that deep, var will be grabbed from the global scoep
+	 */
+	objval->parent_scope = Z_LVAL(copyval);
+}
+
+/* Boolean declarations */
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RD(active)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_access)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_read)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_write)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_eval)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_include)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_echo)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_call)
+PHP_RUNKIT_SANDBOX_SETTING_BOOL_RW(parent_die)
+
+struct _php_runkit_sandbox_settings {
+	char *name;
+	int name_len;
+	zval *(*getter)(php_runkit_sandbox_object *objval TSRMLS_DC);
+	int (*setter)(php_runkit_sandbox_object *objval, zval *value TSRMLS_DC);
+};
+
+struct _php_runkit_sandbox_settings php_runkit_sandbox_settings[] = {
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(output_handler)
+	/* Boolean settings */
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RD(active)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_access)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_read)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_write)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_eval)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_include)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_echo)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_call)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_scope)
+	PHP_RUNKIT_SANDBOX_SETTING_ENTRY_RW(parent_die)
+	{ NULL , 0, NULL, NULL }
+};
+
+static int php_runkit_sandbox_setting_lookup(char *setting, int setting_len) {
+	struct _php_runkit_sandbox_settings *s = php_runkit_sandbox_settings;
+	int i;
+
+	for(i = 0; s[i].name; i++) {
+		if (s[i].name_len == setting_len &&
+			memcmp(s[i].name, setting, setting_len) == 0) {
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+/* {{{ php_runkit_sandbox_read_dimension
+	read_dimension Handler */
+static zval *php_runkit_sandbox_read_dimension(zval *object, zval *member, int type TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval;
+	zval member_copy;
+	int setting_id;
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(object);
+	if (!objval) {
+		return EG(uninitialized_zval_ptr);
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
+
+	setting_id = php_runkit_sandbox_setting_lookup(Z_STRVAL_P(member), Z_STRLEN_P(member));
+
+	if (member == &member_copy) {
+		zval_dtor(member);
+	}
+
+	if (setting_id < 0 || !php_runkit_sandbox_settings[setting_id].getter) {
+		/* No such setting */
+		return EG(uninitialized_zval_ptr);
+	}
+
+	return php_runkit_sandbox_settings[setting_id].getter(objval TSRMLS_CC);
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_write_dimension
+	write_dimension Handler */
+static void php_runkit_sandbox_write_dimension(zval *object, zval *member, zval *value TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval;
+	zval member_copy;
+	int setting_id;
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(object);
+	if (!objval) {
+		return;
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
+
+	setting_id = php_runkit_sandbox_setting_lookup(Z_STRVAL_P(member), Z_STRLEN_P(member));
+
+	if (member == &member_copy) {
+		zval_dtor(member);
+	}
+
+	if (setting_id < 0 || !php_runkit_sandbox_settings[setting_id].setter) {
+		/* No such setting */
+		return;
+	}
+
+	php_runkit_sandbox_settings[setting_id].setter(objval, value TSRMLS_CC);
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_has_dimension
+	has_dimension Handler */
+static int php_runkit_sandbox_has_dimension(zval *object, zval *member, int check_empty TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval;
+	zval member_copy;
+	int setting_id;
+
+	objval = PHP_RUNKIT_SANDBOX_FETCHBOX(object);
+	if (!objval) {
+		return 0;
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
+
+	setting_id = php_runkit_sandbox_setting_lookup(Z_STRVAL_P(member), Z_STRLEN_P(member));
+
+	if (member == &member_copy) {
+		zval_dtor(member);
+	}
+
+	if (setting_id < 0) {
+		/* No such setting */
+		return 0;
+	}
+
+	/* write only offsets are considered non-existent */
+	return php_runkit_sandbox_settings[setting_id].getter ? 1 : 0;
+}
+/* }}} */
+
+/* ********************
+   * Class Definition *
+   ******************** */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_runkit_sandbox__call, 0, 0, 2)
+	ZEND_ARG_PASS_INFO(0)
+	ZEND_ARG_PASS_INFO(0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_runkit_sandbox_functions[] = {
+	PHP_ME(Runkit_Sandbox,		__construct,				NULL,								ZEND_ACC_PUBLIC		| ZEND_ACC_CTOR)
+	PHP_ME(Runkit_Sandbox,		__call,						arginfo_runkit_sandbox__call,		ZEND_ACC_PUBLIC)
+	/* Language Constructs */
+	PHP_ME(Runkit_Sandbox,		eval,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox,		include,					NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox,		include_once,				NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox,		require,					NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox,		require_once,				NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox,		echo,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox,		print,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox,		die,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_MALIAS(Runkit_Sandbox,	exit,	die,				NULL,								ZEND_ACC_PUBLIC)
+	{ NULL, NULL, NULL }
+};
+
+static void php_runkit_sandbox_dtor(php_runkit_sandbox_object *objval TSRMLS_DC)
+{
+	void *prior_context;
+
+
+	prior_context = tsrm_set_interpreter_context(objval->context);
+	{
+		TSRMLS_FETCH();
+
+		if (objval->disable_functions) {
+			efree(objval->disable_functions);
+		}
+
+		if (objval->disable_classes) {
+			efree(objval->disable_classes);
+		}
+
+		php_request_shutdown(TSRMLS_C);
+	}
+	tsrm_set_interpreter_context(NULL);
+	tsrm_free_interpreter_context(objval->context);
+	tsrm_set_interpreter_context(prior_context);
+
+	if (objval->output_handler) {
+		zval_ptr_dtor(&objval->output_handler);
+	}
+	if (objval->parent_scope_name) {
+		efree(objval->parent_scope_name);
+	}
+
+	zend_hash_destroy(objval->obj.properties);
+	FREE_HASHTABLE(objval->obj.properties);
+
+	efree(objval);
+}
+
+static zend_object_value php_runkit_sandbox_ctor(zend_class_entry *ce TSRMLS_DC)
+{
+	php_runkit_sandbox_object *objval;
+	zend_object_value retval;
+
+	objval = ecalloc(1, sizeof(php_runkit_sandbox_object));
+	objval->obj.ce = ce;
+	ALLOC_HASHTABLE(objval->obj.properties);
+	zend_hash_init(objval->obj.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+
+	retval.handle = zend_objects_store_put(objval, NULL, php_runkit_sandbox_dtor, NULL TSRMLS_CC);
+	retval.handlers = &php_runkit_sandbox_object_handlers;
+
+	return retval;
+}
+
+#define PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(method)	if (sapi_module.method) { sapi_module.method = php_runkit_sandbox_sapi_##method; }
+int php_runkit_init_sandbox(INIT_FUNC_ARGS)
+{
+	zend_class_entry ce;
+
+	INIT_CLASS_ENTRY(ce, PHP_RUNKIT_SANDBOX_CLASSNAME, php_runkit_sandbox_functions);
+	php_runkit_sandbox_class_entry = zend_register_internal_class(&ce TSRMLS_CC);
+	php_runkit_sandbox_class_entry->create_object = php_runkit_sandbox_ctor;
+
+	/* Make a new object handler struct with a couple minor changes */
+	memcpy(&php_runkit_sandbox_object_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+	php_runkit_sandbox_object_handlers.read_property			= php_runkit_sandbox_read_property;
+	php_runkit_sandbox_object_handlers.write_property			= php_runkit_sandbox_write_property;
+	php_runkit_sandbox_object_handlers.has_property				= php_runkit_sandbox_has_property;
+	php_runkit_sandbox_object_handlers.unset_property			= php_runkit_sandbox_unset_property;
+
+	/* Dimension access allow introspection and run-time tweaking */
+	php_runkit_sandbox_object_handlers.read_dimension			= php_runkit_sandbox_read_dimension;
+	php_runkit_sandbox_object_handlers.write_dimension			= php_runkit_sandbox_write_dimension;
+	php_runkit_sandbox_object_handlers.has_dimension			= php_runkit_sandbox_has_dimension;
+	php_runkit_sandbox_object_handlers.unset_dimension			= NULL;
+
+	/* ZE has no concept of modifying properties in place via zval** across contexts */
+	php_runkit_sandbox_object_handlers.get_property_ptr_ptr		= NULL;
+
+	/* Wedge ourselves in front of the SAPI */
+	memcpy(&php_runkit_sandbox_original_sapi,					&sapi_module,				sizeof(sapi_module_struct));
+	/* startup -- Not important since it's already fired */
+	/* shutdown -- Not important since we'll be out of the way soon enough */
+	/* activate -- Okay to run as-is */
+	/* deactivate -- Okay to run as-is */
+	sapi_module.ub_write										= php_runkit_sandbox_sapi_ub_write;
+	sapi_module.flush											= php_runkit_sandbox_sapi_flush;
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(get_stat)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(getenv)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(sapi_error)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(header_handler)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(send_headers)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(send_header)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(read_post)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(read_cookies)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(register_server_variables)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(log_message)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(get_request_time)
+	/* php_ini_path_override */
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(block_interruptions)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(unblock_interruptions)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(default_post_reader)
+	/* php_ini_ignore */
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(get_fd)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(force_http_10)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(get_target_uid)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(get_target_gid)
+	PHP_RUNKIT_SANDBOX_SAPI_OVERRIDE(input_filter)
+	/* ini_defaults -- Not important since it's already fired */
+	/* phpinfo_as_text */
+
+	return SUCCESS;
+}
+
+int php_runkit_shutdown_sandbox(SHUTDOWN_FUNC_ARGS)
+{
+	/* Give direct control back to the SAPI */
+	memcpy(&sapi_module,								&php_runkit_sandbox_original_sapi,	sizeof(sapi_module_struct));
+
+	return SUCCESS;
+}
+
+/* ***********************
+   * Lint Implementation *
+   *********************** */
+
+/* {{{ php_runkit_lint_compile
+	Central helper function for runkit_lint() and runkit_lint_file() */
+static void php_runkit_lint_compile(INTERNAL_FUNCTION_PARAMETERS, int filemode)
+{
+	void *context, *prior_context;
+	zval *zcode;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zcode) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	convert_to_string(zcode);
+
+	context = tsrm_new_interpreter_context();
+	prior_context = tsrm_set_interpreter_context(context);
+	{
+		TSRMLS_FETCH();
+
+		php_request_startup(TSRMLS_C);
+		PG(during_request_startup) = 0;
+
+		zend_first_try {
+			char *eval_desc;
+			zend_op_array *op_array;
+
+			if (filemode) {
+				op_array = compile_filename(ZEND_INCLUDE, zcode TSRMLS_CC);
+			} else {
+				eval_desc = zend_make_compiled_string_description("runkit_lint test compile" TSRMLS_CC);
+				op_array = compile_string(zcode, eval_desc TSRMLS_CC);
+				efree(eval_desc);
+			}
+
+			if (op_array)  {
+				RETVAL_TRUE;
+				destroy_op_array(op_array TSRMLS_CC);
+				efree(op_array);
+			} else {
+				RETVAL_FALSE;
+			}
+		} zend_catch {
+			RETVAL_FALSE;
+		} zend_end_try();
+
+		php_request_shutdown(NULL);
+	}
+	tsrm_set_interpreter_context(NULL);
+	tsrm_free_interpreter_context(context);
+	tsrm_set_interpreter_context(prior_context);
+}
+/* }}} */
+
+/* {{{ proto bool runkit_lint(string code)
+	Attempts to compile a string of code within a sub-interpreter */
+PHP_FUNCTION(runkit_lint)
+{
+	php_runkit_lint_compile(INTERNAL_FUNCTION_PARAM_PASSTHRU, 0);
+}
+/* }}} */
+
+/* {{{ proto bool runkit_lint_file(string filename)
+	Attempts to compile a file within a sub-interpreter */
+PHP_FUNCTION(runkit_lint_file)
+{
+	php_runkit_lint_compile(INTERNAL_FUNCTION_PARAM_PASSTHRU, 1);
+}
+/* }}} */
+
+#endif /* PHP_RUNKIT_SANDBOX */
+

--- a/runkit_sandbox_parent.c
+++ b/runkit_sandbox_parent.c
@@ -1,0 +1,661 @@
+/*
+  +----------------------------------------------------------------------+
+  | PHP Version 7                                                        |
+  +----------------------------------------------------------------------+
+  | Copyright (c) 1997-2006 The PHP Group, (c) 2008-2015 Dmitry Zenovich |
+  +----------------------------------------------------------------------+
+  | This source file is subject to the new BSD license,                  |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.opensource.org/licenses/BSD-3-Clause                      |
+  | If you did not receive a copy of the license and are unable to       |
+  | obtain it through the world-wide-web, please send a note to          |
+  | dzenovich@gmail.com so we can mail you a copy immediately.           |
+  +----------------------------------------------------------------------+
+  | Author: Sara Golemon <pollita@php.net>                               |
+  | Modified by Dmitry Zenovich <dzenovich@gmail.com>                    |
+  +----------------------------------------------------------------------+
+*/
+
+/* $Id$ */
+
+#include "php_runkit.h"
+
+#ifdef PHP_RUNKIT_SANDBOX
+#include "php_runkit_sandbox.h"
+#include "php_runkit_zval.h"
+
+static zend_object_handlers php_runkit_sandbox_parent_handlers;
+static zend_class_entry *php_runkit_sandbox_parent_entry;
+
+typedef struct _php_runkit_sandbox_parent_object {
+	zend_object obj;
+	/* This object is for referring to the parent,
+	 * internally it tracks itself
+	 */
+	php_runkit_sandbox_object *self;
+} php_runkit_sandbox_parent_object;
+
+#define PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval) \
+{ \
+	void *prior_context = tsrm_set_interpreter_context(objval->self->parent_context); \
+	TSRMLS_FETCH(); \
+	zend_try {
+
+#define PHP_RUNKIT_SANDBOX_PARENT_ABORT(objval) \
+{ \
+	tsrm_set_interpreter_context(prior_context); \
+}
+
+#define PHP_RUNKIT_SANDBOX_PARENT_END(objval) \
+	} zend_catch { \
+		objval->self->bailed_out_in_eval = 1; \
+	} zend_end_try(); \
+	PHP_RUNKIT_SANDBOX_PARENT_ABORT(objval) \
+	if (objval->self->bailed_out_in_eval) { \
+		/* If the parent is dying, so are we */ \
+		zend_bailout(); \
+	} \
+}
+
+#define PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(zval_p) (php_runkit_sandbox_parent_object*)zend_objects_get_address(zval_p TSRMLS_CC)
+#define PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, pzv) \
+{ \
+	objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(pzv); \
+\
+	if (!objval) { \
+		/* Should never ever happen.... */ \
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "HELP! HELP! MY PARENT HAS ABANDONED ME!"); \
+		RETURN_FALSE; \
+	} \
+\
+	if (!objval->self->parent_access) { \
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to the parent has been suspended"); \
+		RETURN_FALSE; \
+	} \
+}
+
+static HashTable *php_runkit_sandbox_parent_resolve_symbol_table(php_runkit_sandbox_parent_object *objval TSRMLS_DC)
+{
+	int i;
+	HashTable *oldActiveSymbolTable, *result;
+	zend_execute_data *oldCurExData;
+	zend_execute_data *ex = EG(current_execute_data);
+
+	if (!EG(active_symbol_table)) {
+		zend_rebuild_symbol_table(TSRMLS_C);
+	}
+
+	if (objval->self->parent_scope <= 0) {
+		HashTable *ht = &EG(symbol_table);
+
+		if (objval->self->parent_scope_name) {
+			zval **symtable;
+
+			if ((symtable = zend_hash_str_find(ht, objval->self->parent_scope_name, objval->self->parent_scope_namelen + 1)) != NULL) {
+				if (Z_TYPE_PP(symtable) == IS_ARRAY) {
+					ht = Z_ARRVAL_PP(symtable);
+				} else {
+					/* Variable exists but is not an array,
+					 * Make a dummy array that contains this var */
+					zval *hidden;
+
+					ALLOC_INIT_ZVAL(hidden);
+					array_init(hidden);
+					ht = Z_ARRVAL_P(hidden);
+					if (Z_REFCOUNT_PP(symtable) > 1 &&
+						!(*symtable)->RUNKIT_IS_REF) {
+						zval *cv;
+
+						MAKE_STD_ZVAL(cv);
+						*cv = **symtable;
+						zval_copy_ctor(cv);
+						zval_ptr_dtor(symtable);
+						INIT_PZVAL(cv);
+						*symtable = cv;
+					}
+					(*symtable)->RUNKIT_IS_REF = 1;
+					(*symtable)->RUNKIT_REFCOUNT++;  // TODO fix
+					zend_hash_update(ht, objval->self->parent_scope_name, objval->self->parent_scope_namelen + 1, (void*)symtable, sizeof(zval*), NULL);
+
+					/* Store that dummy array in the sandbox's hidden properties table so that it gets cleaned up on dtor */
+					zend_hash_update(objval->obj.properties, "scope", sizeof("scope"), (void*)&hidden, sizeof(zval*), NULL);
+				}
+			} else {
+				/* Create variable as an array */
+				zval *newval;
+
+				ALLOC_INIT_ZVAL(newval);
+				array_init(newval);
+				zend_hash_update(&EG(symbol_table), objval->self->parent_scope_name, objval->self->parent_scope_namelen + 1, (void*)&newval, sizeof(zval*), NULL);
+				ht = Z_ARRVAL_P(newval);
+			}
+		}
+
+		return ht;
+	}
+
+	if (objval->self->parent_scope == 1) {
+		return EG(active_symbol_table);
+	}
+
+	for(i = 1; i < objval->self->parent_scope; i++) {
+		if (!ex->prev_execute_data) {
+			/* Symbol table exceeded */
+			return &EG(symbol_table);
+		}
+		ex = ex->prev_execute_data;
+	}
+
+	oldActiveSymbolTable = EG(active_symbol_table);
+	EG(active_symbol_table) = NULL;
+	oldCurExData = EG(current_execute_data);
+	EG(current_execute_data) = ex;
+	zend_rebuild_symbol_table(TSRMLS_C);
+	result = EG(active_symbol_table);
+	EG(active_symbol_table) = oldActiveSymbolTable;
+	EG(current_execute_data) = oldCurExData;
+	return result;
+}
+
+/* {{{ proto Runkit_Sandbox_Parent::__call(mixed function_name, array args)
+	Call User Function */
+PHP_METHOD(Runkit_Sandbox_Parent,__call)
+{
+	zval *func_name, *args, *retval = NULL;
+	php_runkit_sandbox_parent_object *objval;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "za", &func_name, &args) == FAILURE) {
+		RETURN_NULL();
+	}
+
+	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
+	if (!objval->self->parent_call) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to call functions in the parent context is not enabled");
+		RETURN_FALSE;
+	}
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+	{
+		char *name = NULL;
+
+		if (!RUNKIT_IS_CALLABLE(func_name, IS_CALLABLE_CHECK_NO_ACCESS, &name)) {
+			php_error_docref1(NULL TSRMLS_CC, name, E_WARNING, "Function not defined");
+			if (name) {
+				efree(name);
+			}
+			PHP_RUNKIT_SANDBOX_PARENT_ABORT(objval)
+			RETURN_FALSE;
+		}
+
+		php_runkit_sandbox_call_int(func_name, &name, &retval, args, return_value, prior_context TSRMLS_CC);
+	}
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(return_value);
+
+	if (retval) {
+		PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		zval_ptr_dtor(&retval);
+		PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+	}
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_parent_include_or_eval
+	What's the point of running in a sandbox if you can leave whenever you want to???
+ */
+static void php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAMETERS, int type, int once)
+{
+	php_runkit_sandbox_parent_object *objval;
+	zval *zcode;
+	int bailed_out = 0;
+	zval *retval = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zcode) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	convert_to_string(zcode);
+
+	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
+	if (type == ZEND_EVAL && !objval->self->parent_eval) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to eval() code in the parent context is not enabled");
+		RETURN_FALSE;
+	}
+	if (type != ZEND_EVAL && !objval->self->parent_include) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to include()/include_once()/require()/require_once() in the parent context is not enabled");
+		RETURN_FALSE;
+	}
+
+	RETVAL_NULL();
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		zend_op_array *op_array = NULL;
+		int already_included = 0;
+
+		op_array = php_runkit_sandbox_include_or_eval_int(return_value, zcode, type, once, &already_included TSRMLS_CC);
+
+		if (op_array) {
+			HashTable *old_symbol_table = EG(active_symbol_table);
+			zval **orig_retvalpp = EG(return_value_ptr_ptr);
+			zend_op_array *orig_act_oparray = EG(active_op_array);
+
+			EG(return_value_ptr_ptr) = &retval;
+			EG(active_op_array) = op_array;
+			EG(active_symbol_table) = php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC);
+
+			zend_execute(op_array TSRMLS_CC);
+
+			if (retval) {
+				*return_value = *retval;
+			} else {
+				RETVAL_TRUE;
+			}
+
+			destroy_op_array(op_array TSRMLS_CC);
+			efree(op_array);
+
+			EG(return_value_ptr_ptr) = orig_retvalpp;
+			EG(active_op_array) = orig_act_oparray;
+			EG(active_symbol_table) = old_symbol_table;
+		} else if ((type != ZEND_INCLUDE) && !already_included) {
+			/* include can fail to parse peacefully,
+			 * require and eval should die on failure
+			 */
+			bailed_out = 1;
+		}
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	if (bailed_out) {
+		CG(unclean_shutdown) = 1;
+		CG(in_compilation) = EG(in_execution) = 0;
+		EG(current_execute_data) = NULL;
+		PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+			zend_bailout();
+		PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+	}
+
+	PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(return_value);
+
+	/* Don't confuse the memory manager */
+	if (retval) {
+		PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		zval_ptr_dtor(&retval);
+		PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+	}
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox_Parent::eval(string phpcode)
+	Evaluate php code within the parent */
+PHP_METHOD(Runkit_Sandbox_Parent,eval)
+{
+	php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_EVAL, 0);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox_Parent::include(string filename)
+	Evaluate php code from a file within the parent */
+PHP_METHOD(Runkit_Sandbox_Parent,include)
+{
+	php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_INCLUDE, 0);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox_Parent::include_once(string filename)
+	Evaluate php code from a file within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox_Parent,include_once)
+{
+	php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_INCLUDE, 1);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox_Parent::require(string filename)
+	Evaluate php code from a file within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox_Parent,require)
+{
+	php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_REQUIRE, 0);
+}
+/* }}} */
+
+/* {{{ proto Runkit_Sandbox_Parent::require_once(string filename)
+	Evaluate php code from a file within the sandbox environment */
+PHP_METHOD(Runkit_Sandbox_Parent,require_once)
+{
+	php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAM_PASSTHRU, ZEND_REQUIRE, 1);
+}
+/* }}} */
+
+/* {{{ proto null Runkit_Sandbox_Parent::echo(mixed var[, mixed var[, ... ]])
+	Echo through out of the sandbox
+	Avoid the sandbox's output handler */
+PHP_METHOD(Runkit_Sandbox_Parent,echo)
+{
+	php_runkit_sandbox_parent_object *objval;
+	zval **argv;
+	int i, argc = ZEND_NUM_ARGS();
+
+	if (zend_get_parameters_array_ex(argc, &argv) == FAILURE) {
+		/* Big problems... */
+		RETURN_NULL();
+	}
+
+	for(i = 0; i < argc; i++) {
+		/* Prepare for output */
+		convert_to_string(argv[i]);
+	}
+
+	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
+	if (!objval->self->parent_echo) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to echo data in the parent context is not enabled");
+		RETURN_FALSE;
+	}
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		for(i = 0; i < argc; i++) {
+			PHPWRITE(Z_STRVAL_P(argv[i]),Z_STRLEN_P(argv[i]));
+		}
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	RETURN_NULL();
+}
+/* }}} */
+
+/* {{{ proto bool Runkit_Sandbox_Parent::print(mixed var)
+	Echo through the sandbox
+	Avoid the sandbox's output_handler */
+PHP_METHOD(Runkit_Sandbox_Parent,print)
+{
+	php_runkit_sandbox_parent_object *objval;
+	char *str;
+	int len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &len) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
+	if (!objval->self->parent_echo) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to echo data in the parent context is not enabled");
+		RETURN_FALSE;
+	}
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		PHPWRITE(str,len);
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	RETURN_BOOL(len > 1 || (len == 1 && str[0] != '0'));
+}
+/* }}} */
+
+/* {{{ proto void Runkit_Sandbox_Parent::die(mixed message)
+	MALIAS(exit)
+	PATRICIDE!!!!!!!! */
+PHP_METHOD(Runkit_Sandbox_Parent,die)
+{
+	php_runkit_sandbox_parent_object *objval;
+	zval *message = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z", &message) == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	RETVAL_NULL();
+
+	if (message && Z_TYPE_P(message) != IS_LONG) {
+		convert_to_string(message);
+	}
+
+	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
+	if (!objval->self->parent_die) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Patricide is disabled.  Shame on you Oedipus.");
+		/* Sent as a warning, but we'll really implement it as an E_ERROR */
+		objval->self->active = 0;
+		RETURN_FALSE;
+	}
+
+	CG(unclean_shutdown) = 1;
+	CG(in_compilation) = EG(in_execution) = 0;
+	EG(current_execute_data) = NULL;
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		if (message) {
+			if (Z_TYPE_P(message) == IS_LONG) {
+				EG(exit_status) = Z_LVAL_P(message);
+			} else {
+				PHPWRITE(Z_STRVAL_P(message), Z_STRLEN_P(message));
+			}
+		}
+		zend_bailout();
+		/* More of a murder-suicide really... */
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+}
+/* }}} */
+
+/* *********************
+   * Property Handlers *
+   ********************* */
+
+/* {{{ php_runkit_sandbox_parent_read_property
+	read_property handler */
+static zval *php_runkit_sandbox_parent_read_property(zval *object, zval *member, int type
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_parent_object *objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
+	zval tmp_member;
+	zval retval;
+	int prop_found = 0;
+
+	if (!objval) {
+		return EG(uninitialized_zval_ptr);
+	}
+	if (!objval->self->parent_access || !objval->self->parent_read) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to read parent's symbol table is disallowed");
+		return EG(uninitialized_zval_ptr);
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, tmp_member);
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		zval **value;
+
+		if ((value = zend_hash_str_find(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1)) != NULL) {
+			retval = **value;
+			prop_found = 1;
+		}
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	if (member == &tmp_member) {
+		zval_dtor(member);
+	}
+
+	return php_runkit_sandbox_return_property_value(prop_found, &retval TSRMLS_CC);
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_parent_write_property
+	write_property handler */
+static void php_runkit_sandbox_parent_write_property(zval *object, zval *member, zval *value
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_parent_object *objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
+	zval tmp_member;
+
+	if (!objval) {
+		return;
+	}
+	if (!objval->self->parent_access || !objval->self->parent_write) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to modify parent's symbol table is disallowed");
+		return;
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, tmp_member);
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		zval *copyval;
+
+		MAKE_STD_ZVAL(copyval);
+		*copyval = *value;
+		PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(copyval);
+		ZEND_SET_SYMBOL(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), copyval);
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	if (member == &tmp_member) {
+		zval_dtor(member);
+	}
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_parent_has_property
+	has_property handler */
+static int php_runkit_sandbox_parent_has_property(zval *object, zval *member, int has_set_exists
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_parent_object* objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
+	zval member_copy;
+	int result = 0;
+
+	if (!objval || !objval->self->parent_access || !objval->self->parent_read) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to read parent's symbol table is disallowed");
+		return 0;
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		php_runkit_sandbox_has_property_int(has_set_exists, member TSRMLS_CC);
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	if (member == &member_copy) {
+		zval_dtor(member);
+	}
+
+	return result;
+}
+/* }}} */
+
+/* {{{ php_runkit_sandbox_parent_unset_property
+	unset_property handler */
+static void php_runkit_sandbox_parent_unset_property(zval *object, zval *member
+	, const zend_literal *key
+	TSRMLS_DC)
+{
+	php_runkit_sandbox_parent_object *objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
+	zval member_copy;
+
+	if (!objval) {
+		return;
+	}
+	if (!objval->self->parent_access || !objval->self->parent_write) {
+		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to modify parent's symbol table is disallowed");
+		return;
+	}
+
+	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
+
+	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
+		if (zend_hash_exists(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1)) {
+			/* Simply removing the zval* causes weirdness with CVs */
+			zend_hash_update(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void*)&EG(uninitialized_zval_ptr), sizeof(zval*), NULL);
+		}
+	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
+
+	if (member == &member_copy) {
+		zval_dtor(member);
+	}
+}
+/* }}} */
+
+/* ********************
+   * Class Definition *
+   ******************** */
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_runkit_sandbox_parent__call, 0, 0, 2)
+	ZEND_ARG_PASS_INFO(0)
+	ZEND_ARG_PASS_INFO(0)
+ZEND_END_ARG_INFO()
+
+static zend_function_entry php_runkit_sandbox_parent_functions[] = {
+	PHP_ME(Runkit_Sandbox_Parent,		__call,						arginfo_runkit_sandbox_parent__call,ZEND_ACC_PUBLIC)
+	/* Language Constructs */
+	PHP_ME(Runkit_Sandbox_Parent,		eval,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox_Parent,		include,					NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox_Parent,		include_once,				NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox_Parent,		require,					NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox_Parent,		require_once,				NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox_Parent,		echo,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox_Parent,		print,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_ME(Runkit_Sandbox_Parent,		die,						NULL,								ZEND_ACC_PUBLIC)
+	PHP_MALIAS(Runkit_Sandbox_Parent,	exit,	die,				NULL,								ZEND_ACC_PUBLIC)
+	{ NULL, NULL, NULL }
+};
+
+static void php_runkit_sandbox_parent_dtor(php_runkit_sandbox_parent_object *objval TSRMLS_DC)
+{
+	zend_hash_destroy(objval->obj.properties);
+	FREE_HASHTABLE(objval->obj.properties);
+
+	efree(objval);
+}
+
+static zend_object_value php_runkit_sandbox_parent_ctor(zend_class_entry *ce TSRMLS_DC)
+{
+	php_runkit_sandbox_parent_object *objval;
+	zend_object_value retval;
+
+	if (RUNKIT_G(current_sandbox)) {
+		objval = ecalloc(1, sizeof(php_runkit_sandbox_parent_object));
+		objval->obj.ce = ce;
+		objval->self = RUNKIT_G(current_sandbox);
+	} else {
+		/* Assign a "blind" stdClass when invoked from the top-scope */
+		objval = ecalloc(1, sizeof(zend_object));
+		objval->obj.ce = zend_standard_class_def;
+	}
+	ALLOC_HASHTABLE(objval->obj.properties);
+	zend_hash_init(objval->obj.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
+	retval.handle = zend_objects_store_put(objval, NULL, (zend_objects_free_object_storage_t)php_runkit_sandbox_parent_dtor, NULL TSRMLS_CC);
+
+	retval.handlers = RUNKIT_G(current_sandbox) ? &php_runkit_sandbox_parent_handlers : zend_get_std_object_handlers();
+
+	return retval;
+}
+
+int php_runkit_init_sandbox_parent(INIT_FUNC_ARGS)
+{
+	zend_class_entry ce;
+
+	INIT_CLASS_ENTRY(ce, PHP_RUNKIT_SANDBOX_PARENT_CLASSNAME, php_runkit_sandbox_parent_functions);
+	php_runkit_sandbox_parent_entry = zend_register_internal_class(&ce TSRMLS_CC);
+	php_runkit_sandbox_parent_entry->create_object = php_runkit_sandbox_parent_ctor;
+
+	/* Make a new object handler struct with a couple minor changes */
+	memcpy(&php_runkit_sandbox_parent_handlers, zend_get_std_object_handlers(), sizeof(zend_object_handlers));
+	php_runkit_sandbox_parent_handlers.read_property			= php_runkit_sandbox_parent_read_property;
+	php_runkit_sandbox_parent_handlers.write_property			= php_runkit_sandbox_parent_write_property;
+	php_runkit_sandbox_parent_handlers.has_property				= php_runkit_sandbox_parent_has_property;
+	php_runkit_sandbox_parent_handlers.unset_property			= php_runkit_sandbox_parent_unset_property;
+
+	/* No dimension access for parent (initially) */
+	php_runkit_sandbox_parent_handlers.read_dimension			= NULL;
+	php_runkit_sandbox_parent_handlers.write_dimension			= NULL;
+	php_runkit_sandbox_parent_handlers.has_dimension			= NULL;
+	php_runkit_sandbox_parent_handlers.unset_dimension			= NULL;
+
+	/* ZE has no concept of modifying properties in place via zval** across contexts */
+	php_runkit_sandbox_parent_handlers.get_property_ptr_ptr		= NULL;
+
+	return SUCCESS;
+}
+
+int php_runkit_shutdown_sandbox_parent(SHUTDOWN_FUNC_ARGS)
+{
+	return SUCCESS;
+}
+
+#endif /* PHP_RUNKIT_SANDBOX */
+

--- a/runkit_sandbox_parent.c
+++ b/runkit_sandbox_parent.c
@@ -3,6 +3,7 @@
   | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
   | Copyright (c) 1997-2006 The PHP Group, (c) 2008-2015 Dmitry Zenovich |
+  | "runkit7" patches (c) 2015-2017 Tyson Andre                          |
   +----------------------------------------------------------------------+
   | This source file is subject to the new BSD license,                  |
   | that is bundled with this package in the file LICENSE, and is        |
@@ -14,6 +15,7 @@
   +----------------------------------------------------------------------+
   | Author: Sara Golemon <pollita@php.net>                               |
   | Modified by Dmitry Zenovich <dzenovich@gmail.com>                    |
+  | Modified for php7 by Tyson Andre <tysonandre775@hotmail.com>         |
   +----------------------------------------------------------------------+
 */
 
@@ -25,6 +27,8 @@
 #include "php_runkit_sandbox.h"
 #include "php_runkit_zval.h"
 
+// FIXME reintroduce and fix compilation errors
+#if 0
 static zend_object_handlers php_runkit_sandbox_parent_handlers;
 static zend_class_entry *php_runkit_sandbox_parent_entry;
 
@@ -656,6 +660,7 @@ int php_runkit_shutdown_sandbox_parent(SHUTDOWN_FUNC_ARGS)
 {
 	return SUCCESS;
 }
+#endif
 
 #endif /* PHP_RUNKIT_SANDBOX */
 

--- a/tests/Runkit_Sandbox.allow_url_include.phpt
+++ b/tests/Runkit_Sandbox.allow_url_include.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Runkit_Sandbox - Allow disabling of allow_url_include
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; ?>
+--INI--
+allow_url_include="On"
+--FILE--
+<?php
+var_dump(ini_get('allow_url_include'));
+
+$s = new Runkit_Sandbox(array(
+  'allow_url_include' => false,
+));
+
+var_dump($s->ini_get('allow_url_include'));
+
+--EXPECT--
+string(2) "On"
+string(1) "0"

--- a/tests/Runkit_Sandbox.open_basedir.phpt
+++ b/tests/Runkit_Sandbox.open_basedir.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Runkit_Sandbox - Prevent overriding open_basedir when a bogus path is present
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; ?>
+--INI--
+open_basedir="/bogus-does-not-exist-runkit-test-dir"
+--FILE--
+<?php
+//ini_set('open_basedir', '/bogus-does-not-exist-runkit-test-dir');
+var_dump(ini_get('open_basedir'));
+
+$s = new Runkit_Sandbox(array(
+  'open_basedir' => dirname(__FILE__),
+));
+
+var_dump(dirname(__FILE__) === $s->ini_get('open_basedir'));
+
+--EXPECT--
+string(37) "/bogus-does-not-exist-runkit-test-dir"
+bool(false)

--- a/tests/Runkit_Sandbox_.active.phpt
+++ b/tests/Runkit_Sandbox_.active.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Runkit_Sandbox['active'] status
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+var_dump($php['active']);
+echo $php->die("What a world...\n");
+var_dump($php['active']);
+--EXPECT--
+bool(true)
+What a world...
+bool(false)

--- a/tests/Runkit_Sandbox_.output_handler.phpt
+++ b/tests/Runkit_Sandbox_.output_handler.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Runkit_Sandbox['output_handler'] setting
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['output_handler'] = 'test_handler';
+$php->echo("foo\n");
+$php->echo("Barish\n");
+$php->echo("BAZimbly\n");
+var_dump($php['output_handler']);
+
+function test_handler($str) {
+  if (strlen($str) == 0) return NULL; /* Do nothing with flush events */
+  /* Echoing and returning have the same effect here, both go to parent's output chain */
+  echo 'Received string from sandbox: ' . strlen($str) . " bytes long.\n";
+
+  return strtoupper($str);
+}
+--EXPECT--
+Received string from sandbox: 4 bytes long.
+FOO
+Received string from sandbox: 7 bytes long.
+BARISH
+Received string from sandbox: 9 bytes long.
+BAZIMBLY
+string(12) "test_handler"

--- a/tests/Runkit_Sandbox_Parent1.phpt
+++ b/tests/Runkit_Sandbox_Parent1.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Instantiation from outter scope
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+var_dump(new Runkit_Sandbox_Parent());
+--EXPECTF--
+object(stdClass)#%d (0) {
+}
+

--- a/tests/Runkit_Sandbox_Parent2.phpt
+++ b/tests/Runkit_Sandbox_Parent2.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Locked Access
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$one = 1;
+$php = new Runkit_Sandbox();
+/* read == true is useless without parent_access set */
+$php['parent_read'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			var_dump($PARENT->one);');
+--EXPECTF--
+Warning: Unknown: Access to read parent's symbol table is disallowed in Unknown(0) : Runkit_Sandbox Eval Code on line %d
+NULL

--- a/tests/Runkit_Sandbox_Parent__.call.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.call.access.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Locked Call
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->foo();');
+
+function foo() {
+	echo "Bar\n";
+}
+--EXPECTF--
+Warning: Runkit_Sandbox_Parent::__call(): Access to call functions in the parent context is not enabled in Unknown(0) : Runkit_Sandbox Eval Code on line %d

--- a/tests/Runkit_Sandbox_Parent__.call.phpt
+++ b/tests/Runkit_Sandbox_Parent__.call.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Call
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php['parent_call'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->foo();');
+
+function foo() {
+	echo "Bar\n";
+}
+--EXPECTF--
+Bar

--- a/tests/Runkit_Sandbox_Parent__.die.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.die.access.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Locked Patricide
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+echo "Before die()\n";
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->die();');
+echo "After die()\n";
+--EXPECT--
+Before die()
+
+Warning: Runkit_Sandbox_Parent::die(): Patricide is disabled.  Shame on you Oedipus. in Unknown(0) : Runkit_Sandbox Eval Code on line 2
+After die()

--- a/tests/Runkit_Sandbox_Parent__.die.phpt
+++ b/tests/Runkit_Sandbox_Parent__.die.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Patricide
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php['parent_die'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+echo "Before die()\n";
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->die();');
+echo "After die()\n";
+--EXPECT--
+Before die()

--- a/tests/Runkit_Sandbox_Parent__.echo.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.echo.access.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Echo
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['output_handler'] = 'test_handler';
+$php['parent_access'] = true;
+$php->ini_set('display_errors', true);
+$php->ini_set('html_errors', false);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			echo "Foo\n";
+			$PARENT->echo("BarBar\n");');
+
+function test_handler($str) {
+  if (strlen($str) == 0) return NULL; /* flush() */
+  /* Echoing and returning have the same effect here, both go to parent's output chain */
+  echo 'Received string from sandbox: ' . strlen($str) . " bytes long.\n";
+
+  return strtoupper($str);
+}
+--EXPECT--
+Received string from sandbox: 4 bytes long.
+FOO
+Received string from sandbox: 149 bytes long.
+
+WARNING: RUNKIT_SANDBOX_PARENT::ECHO(): ACCESS TO ECHO DATA IN THE PARENT CONTEXT IS NOT ENABLED IN UNKNOWN(0) : RUNKIT_SANDBOX EVAL CODE ON LINE 3

--- a/tests/Runkit_Sandbox_Parent__.echo.phpt
+++ b/tests/Runkit_Sandbox_Parent__.echo.phpt
@@ -1,0 +1,29 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Echo
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['output_handler'] = 'test_handler';
+$php['parent_access'] = true;
+$php['parent_echo'] = true;
+$php->ini_set('display_errors', true);
+$php->ini_set('html_errors', false);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			echo "Foo\n";
+			$PARENT->echo("BarBar\n");');
+
+function test_handler($str) {
+  if (strlen($str) == 0) return NULL; /* flush() */
+  /* Echoing and returning have the same effect here, both go to parent's output chain */
+  echo 'Received string from sandbox: ' . strlen($str) . " bytes long.\n";
+
+  return strtoupper($str);
+}
+--EXPECT--
+Received string from sandbox: 4 bytes long.
+FOO
+BarBar

--- a/tests/Runkit_Sandbox_Parent__.eval.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.eval.access.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Locked Eval
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->eval(\'var_dump($php);\');');
+--EXPECT--
+Warning: Runkit_Sandbox_Parent::eval(): Access to eval() code in the parent context is not enabled in Unknown(0) : Runkit_Sandbox Eval Code on line 2

--- a/tests/Runkit_Sandbox_Parent__.eval.phpt
+++ b/tests/Runkit_Sandbox_Parent__.eval.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Eval
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+	  /* May not be available due to lack of TSRM interpreter support */
+	  if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php['parent_eval'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->eval(\'var_dump($php);\');');
+--EXPECT--
+object(Runkit_Sandbox)#1 (0) {
+}

--- a/tests/Runkit_Sandbox_Parent__.read.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.read.access.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Locked Read Access
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$one = 1;
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			var_dump($PARENT->one);');
+--EXPECTF--
+Warning: Unknown: Access to read parent's symbol table is disallowed in Unknown(0) : Runkit_Sandbox Eval Code on line %d
+NULL

--- a/tests/Runkit_Sandbox_Parent__.read.phpt
+++ b/tests/Runkit_Sandbox_Parent__.read.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Read Access
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$one = 1;
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php['parent_read'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			var_dump($PARENT->one);');
+--EXPECTF--
+int(1)

--- a/tests/Runkit_Sandbox_Parent__.scope.phpt
+++ b/tests/Runkit_Sandbox_Parent__.scope.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Scopes
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php['parent_read'] = true;
+$php->ini_set('display_errors', true);
+$php->ini_set('html_errors', false);
+
+$test = "Global";
+
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;');
+
+$php['parent_scope'] = 0;
+one();
+
+$php['parent_scope'] = 1;
+one();
+
+$php['parent_scope'] = 2;
+one();
+
+$php['parent_scope'] = 3;
+one();
+
+$php['parent_scope'] = 4;
+one();
+
+$php['parent_scope'] = 5;
+one();
+
+function one() {
+	$test = "one()";
+	two();
+}
+
+function two() {
+	$test = "two()";
+	three();
+}
+
+function three() {
+	$test = "three()";
+	$GLOBALS['php']->eval('var_dump($PARENT->test);');
+}
+--EXPECT--
+string(6) "Global"
+string(7) "three()"
+string(5) "two()"
+string(5) "one()"
+string(6) "Global"
+string(6) "Global"

--- a/tests/Runkit_Sandbox_Parent__.write.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.write.access.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Locked Write Access
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->one = 1;');
+var_dump($one);
+--EXPECTF--
+Warning: Unknown: Access to modify parent's symbol table is disallowed in Unknown(0) : Runkit_Sandbox Eval Code on line %d
+
+Notice: Undefined variable: one in %s on line %d
+NULL

--- a/tests/Runkit_Sandbox_Parent__.write.phpt
+++ b/tests/Runkit_Sandbox_Parent__.write.phpt
@@ -1,0 +1,19 @@
+--TEST--
+Runkit_Sandbox_Parent Class -- Write Access
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['parent_access'] = true;
+$php['parent_write'] = true;
+$php->ini_set('html_errors',false);
+$php->ini_set('display_errors',true);
+$php->error_reporting(E_ALL);
+$php->eval('$PARENT = new Runkit_Sandbox_Parent;
+			$PARENT->one = 1;');
+var_dump($one);
+--EXPECTF--
+int(1)

--- a/tests/Runkit_Sandbox__call.phpt
+++ b/tests/Runkit_Sandbox__call.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Runkit_Sandbox::__call() method
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+echo $php->str_replace('foo','bar',"The word of the day is foo\n");
+--EXPECT--
+The word of the day is bar

--- a/tests/Runkit_Sandbox__call_user_func_closure.phpt
+++ b/tests/Runkit_Sandbox__call_user_func_closure.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Runkit_Sandbox::__call_user_func() method with closure as the first parameter
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip";
+      if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
+?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php->a = "OK\n";
+$php->call_user_func(function() { global $a; print $a; }); /* As of PHP 5.3.0 */
+--EXPECT--
+OK

--- a/tests/Runkit_Sandbox__die.phpt
+++ b/tests/Runkit_Sandbox__die.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Runkit_Sandbox::die() method
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php->ini_set('html_errors',false);
+echo $php->echo('foo');
+echo $php->die();
+echo $php->echo('bar');
+--EXPECTF--
+foo
+Warning: Runkit_Sandbox::echo(): Current sandbox is no longer active in %s on line %d

--- a/tests/Runkit_Sandbox__disable_classes.phpt
+++ b/tests/Runkit_Sandbox__disable_classes.phpt
@@ -1,0 +1,13 @@
+--TEST--
+Runkit_Sandbox() - disable_classes test
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox(array('disable_classes'=>'stdClass'));
+$php->ini_set('html_errors',false);
+$php->eval('$a = new stdClass();');
+--EXPECTF--
+Warning: std%slass() has been disabled for security reasons in Unknown(0) : Runkit_Sandbox Eval Code on line 1

--- a/tests/Runkit_Sandbox__disable_functions.phpt
+++ b/tests/Runkit_Sandbox__disable_functions.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Runkit_Sandbox() - disable_functions test
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox(array('disable_functions'=>'php_sapi_name'));
+$php->ini_set('html_errors',false);
+$php->eval('php_sapi_name();');
+--EXPECT--
+Warning: php_sapi_name() has been disabled for security reasons in Unknown(0) : Runkit_Sandbox Eval Code on line 1
+

--- a/tests/Runkit_Sandbox__echo.phpt
+++ b/tests/Runkit_Sandbox__echo.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Runkit_Sandbox::echo() method
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+echo $php->echo("foo\n","bar\n","baz\n");
+--EXPECT--
+foo
+bar
+baz

--- a/tests/Runkit_Sandbox__eval.phpt
+++ b/tests/Runkit_Sandbox__eval.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Runkit_Sandbox::eval() method
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php->eval('var_dump(isset($php)); $test = 123; echo "$test\n";');
+var_dump(isset($test));
+--EXPECT--
+bool(false)
+123
+bool(false)

--- a/tests/Runkit_Sandbox__get.phpt
+++ b/tests/Runkit_Sandbox__get.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Runkit_Sandbox::__get() method
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$test = 123;
+$php->eval('$test = 321;');
+var_dump($php->test);
+var_dump($test);
+--EXPECT--
+int(321)
+int(123)

--- a/tests/Runkit_Sandbox__grandchild.phpt
+++ b/tests/Runkit_Sandbox__grandchild.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Runkit_Sandbox Nesting
+--SKIPIF--
+<?php if(!extension_loaded("runkit")) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$php['output_handler'] = 'child_output';
+$php->eval('echo "Foo\n";
+			$grandchild = new Runkit_Sandbox();
+			$grandchild["output_handler"] = "grandchild_output";
+			$grandchild->eval(\'echo "Bar\n";\');
+			echo "Baz\n";
+
+			function grandchild_output($str) {
+				if (strlen($str) == 0) return NULL; /* flush() */
+				return "Grandchild Says: $str";
+			}');
+
+echo "Bling\n";
+$php->echo("Blong\n");
+
+function child_output($str) {
+	if (strlen($str) == 0) return NULL; /* flush() */
+	return "Child Says: $str";
+}
+
+--EXPECT--
+Child Says: Foo
+Child Says: Grandchild Says: Bar
+Child Says: Baz
+Bling
+Child Says: Blong

--- a/tests/Runkit_Sandbox__set.phpt
+++ b/tests/Runkit_Sandbox__set.phpt
@@ -1,0 +1,16 @@
+--TEST--
+Runkit_Sandbox::__set() method
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_lint")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+$test = 123;
+$php->test = 321;
+$php->eval('var_dump($test);');
+var_dump($test);
+--EXPECT--
+int(321)
+int(123)

--- a/tests/bug64496.phpt
+++ b/tests/bug64496.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Bug #64496 - Runkit_Sandbox override of open_basedir when parent uses multiple paths
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+      if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
+?>
+--FILE--
+<?php
+$tmp = realpath(sys_get_temp_dir());
+$dir = realpath(dirname(__FILE__));
+$parent = realpath(dirname(dirname(dirname(__FILE__))));
+ini_set('open_basedir', sys_get_temp_dir() . PATH_SEPARATOR . dirname(dirname(__FILE__)));
+
+foreach(array(
+  $tmp . PATH_SEPARATOR . $dir,
+  $dir . PATH_SEPARATOR . $tmp,
+  $dir,
+  $tmp,
+  DIRECTORY_SEPARATOR . 'bogus-does-not-exist-runkit-test-dir',
+  $parent,
+) as $idx => $path) {
+  $s = new Runkit_Sandbox(array(
+    'open_basedir' =>  $path
+  ));
+
+  echo "$idx: ";
+  var_dump($path === $s->ini_get('open_basedir'));
+}
+--EXPECT--
+0: bool(true)
+1: bool(true)
+2: bool(true)
+3: bool(true)
+4: bool(false)
+5: bool(false)

--- a/tests/runkit_sandbox_output_handler.phpt
+++ b/tests/runkit_sandbox_output_handler.phpt
@@ -1,0 +1,29 @@
+--TEST--
+runkit_sandbox_output_handler() function
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+      /* May not be available due to lack of TSRM interpreter support */
+      if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+runkit_sandbox_output_handler($php, 'test_handler');
+$php->echo("foo\n");
+$php->echo("Barish\n");
+$php->echo("BAZimbly\n");
+
+function test_handler($str) {
+  if (strlen($str) == 0) return NULL; /* flush() */
+  /* Echoing and returning have the same effect here, both go to parent's output chain */
+  echo 'Received string from sandbox: ' . strlen($str) . " bytes long.\n";
+
+  return strtoupper($str);
+}
+--EXPECTF--
+Notice: runkit_sandbox_output_handler(): Use of runkit_sandbox_output_handler() is deprecated.  Use $sandbox['output_handler'] instead. in %s on line %d
+Received string from sandbox: 4 bytes long.
+FOO
+Received string from sandbox: 7 bytes long.
+BARISH
+Received string from sandbox: 9 bytes long.
+BAZIMBLY

--- a/tests/runkit_sandbox_with_register_globals.phpt
+++ b/tests/runkit_sandbox_with_register_globals.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Runkit_Sandbox with register_globals
+--SKIPIF--
+<?php
+  if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) echo "skip";
+  if(version_compare(PHP_VERSION, '5.3.999', '>')) echo "skip";
+?>
+--INI--
+register_globals=On
+--FILE--
+<?php
+$php = new Runkit_Sandbox();
+--EXPECTREGEX--
+(((PHP )?Warning|Deprecated):\s+Directive 'register_globals' is deprecated in PHP 5\.3 and greater in Unknown on line 0)?(Fatal error: Directive 'register_globals' is no longer available in PHP in Unknown on line 0)?
+--DONE--


### PR DESCRIPTION
I worked on `runkit_lint()`, but ran into issues with the php thread switching APIs. PHP7 has internal state that PHP5 didn't, causing crashes or valgrind errors. (runkit for PHP 5 didn't actually switch threads, it just saved and restored state).
Additionally, the thread switching API has unclear documentation (Couldn't find examples of it being used in php7? Maybe apache has something).
A much more stable approach would be to actually use threads, but this seems like it would require an SAPI such as the PHP CLI to be included.


This fixes some php7 compilation errors, and reintroduces the sandbox files (Still not fully compatible with php7, so disabled via C macros.)