### PR TITLE
Remove TSRMLS_* macros that are actually no-ops in php 7.0+

### DIFF
--- a/php_runkit.h
+++ b/php_runkit.h
@@ -217,10 +217,10 @@ extern ZEND_DECLARE_MODULE_GLOBALS(runkit)
 #define RUNKIT_TSRMLS_C		, NULL
 #endif
 
-#define RUNKIT_IS_CALLABLE(cb_zv, flags, cb_sp) zend_is_callable((cb_zv), (flags), (cb_sp) TSRMLS_CC)
-#define RUNKIT_FILE_HANDLE_DTOR(pHandle)        zend_file_handle_dtor((pHandle) TSRMLS_CC)
-#define RUNKIT_53_TSRMLS_PARAM(param)           (param) TSRMLS_CC
-#define RUNKIT_53_TSRMLS_ARG(arg)               arg TSRMLS_DC
+#define RUNKIT_IS_CALLABLE(cb_zv, flags, cb_sp) zend_is_callable((cb_zv), (flags), (cb_sp))
+#define RUNKIT_FILE_HANDLE_DTOR(pHandle)        zend_file_handle_dtor((pHandle))
+#define RUNKIT_53_TSRMLS_PARAM(param)           (param)
+#define RUNKIT_53_TSRMLS_ARG(arg)               arg
 
 #ifdef ZEND_ACC_RETURN_REFERENCE
 #     define PHP_RUNKIT_ACC_RETURN_REFERENCE         ZEND_ACC_RETURN_REFERENCE
@@ -262,23 +262,23 @@ static inline void *runkit_zend_hash_add_or_update_ptr(HashTable *ht, zend_strin
 
 /* runkit_functions.c */
 #define RUNKIT_TEMP_FUNCNAME  "__runkit_temporary_function__"
-int php_runkit_check_call_stack(zend_op_array *op_array TSRMLS_DC);
+int php_runkit_check_call_stack(zend_op_array *op_array);
 void php_runkit_clear_all_functions_runtime_cache(TSRMLS_D);
-void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, zend_function *called_f TSRMLS_DC);
+void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, zend_function *called_f);
 
-void php_runkit_remove_function_from_reflection_objects(zend_function *fe TSRMLS_DC);
-// void php_runkit_function_copy_ctor(zend_function *fe, zend_string *newname, char orig_fe_type TSRMLS_DC);
-zend_function* php_runkit_function_clone(zend_function *fe, zend_string *newname, char orig_fe_type TSRMLS_DC);
+void php_runkit_remove_function_from_reflection_objects(zend_function *fe);
+// void php_runkit_function_copy_ctor(zend_function *fe, zend_string *newname, char orig_fe_type);
+zend_function* php_runkit_function_clone(zend_function *fe, zend_string *newname, char orig_fe_type);
 void php_runkit_function_dtor(zend_function *fe);
 int php_runkit_remove_from_function_table(HashTable *function_table, zend_string *func_lower);
 void* php_runkit_update_function_table(HashTable *function_table, zend_string *func_lower, zend_function *f);
 int php_runkit_generate_lambda_method(const zend_string *arguments, const zend_string *return_type, const zend_bool is_strict, const zend_string *phpcode,
-                                      zend_function **pfe, zend_bool return_ref, zend_bool is_static TSRMLS_DC);
+                                      zend_function **pfe, zend_bool return_ref, zend_bool is_static);
 int php_runkit_generate_lambda_function(const zend_string *arguments, const zend_string *return_type, const zend_bool is_strict, const zend_string *phpcode,
-                                      zend_function **pfe, zend_bool return_ref TSRMLS_DC);
+                                      zend_function **pfe, zend_bool return_ref);
 int php_runkit_cleanup_lambda_method();
 int php_runkit_cleanup_lambda_function();
-int php_runkit_destroy_misplaced_functions(zval *pDest TSRMLS_DC);
+int php_runkit_destroy_misplaced_functions(zval *pDest);
 void php_runkit_restore_internal_function(zend_string *fname_lower, zend_function *f);
 
 /* runkit_methods.c */
@@ -288,10 +288,10 @@ void php_runkit_clean_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *ce
 void php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_ARG(HashTable *ht), zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_string *fname_lower, zend_function *orig_cfe);
 void php_runkit_update_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *ce), zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_function *fe, zend_string *fname_lower, zend_function *orig_fe);
 void php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_ARG(HashTable *ht), zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_function *fe, zend_string *fname_lower, zend_function *orig_fe);
-int php_runkit_fetch_interface(zend_string *classname, zend_class_entry **pce TSRMLS_DC);
+int php_runkit_fetch_interface(zend_string *classname, zend_class_entry **pce);
 
 /* Redundant unless 7.1 changes - string may no longer apply */
-#define PHP_RUNKIT_FUNCTION_ADD_REF(f)	function_add_ref(f TSRMLS_CC)
+#define PHP_RUNKIT_FUNCTION_ADD_REF(f)	function_add_ref(f)
 #define php_runkit_locate_scope(ce, fe, methodname_lower)   fe->common.scope
 #define PHP_RUNKIT_STRTOLOWER(param)			php_u_strtolower(param, &param##_len, UG(default_locale))
 #define PHP_RUNKIT_STRING_LEN(param,addtl)		(param##_type == IS_UNICODE ? UBYTES(param##_len + (addtl)) : (param##_len + (addtl)))
@@ -299,22 +299,22 @@ int php_runkit_fetch_interface(zend_string *classname, zend_class_entry **pce TS
 #define PHP_RUNKIT_HASH_FIND(hash,param,ppvar)		zend_u_hash_find(hash, param##_type, (UChar *)param, param##_len + 1, (void*)ppvar)
 #define PHP_RUNKIT_HASH_EXISTS(hash,param)		zend_u_hash_exists(hash, param##_type, (UChar *)param, param##_len + 1)
 
-#define PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR php_error_docref(NULL TSRMLS_CC, E_ERROR, "Not enough memory")
+#define PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR php_error_docref(NULL, E_ERROR, "Not enough memory")
 
 /* runkit_constants.c */
 void php_runkit_update_children_consts(zend_class_entry *ce, zend_class_entry *parent_class, zval *c, zend_string *cname RUNKIT_CONST_FLAGS_DC(access_type));
 void php_runkit_update_children_consts_foreach(HashTable *ht, zend_class_entry *parent_class, zval *c, zend_string *cname RUNKIT_CONST_FLAGS_DC(access_type));
 
 /* runkit_classes.c */
-int php_runkit_class_copy(zend_class_entry *src, zend_string *classname TSRMLS_DC);
+int php_runkit_class_copy(zend_class_entry *src, zend_string *classname);
 
 /* runkit_props.c */
 void php_runkit_update_children_def_props(zend_class_entry *ce, zend_class_entry *parent_class, zval *p, zend_string *pname, int access_type, zend_class_entry *definer_class, int override, int override_in_objects);
 int php_runkit_def_prop_add_int(zend_class_entry *ce, zend_string* propname, zval *copyval, long visibility,
                                 zend_string* doc_comment, zend_class_entry *definer_class, int override,
-                                int override_in_objects TSRMLS_DC);
+                                int override_in_objects);
 int php_runkit_def_prop_remove_int(zend_class_entry *ce, zend_string* propname, zend_class_entry *definer_class,
-                                   zend_bool was_static, zend_bool remove_from_objects, zend_property_info *parent_property TSRMLS_DC);
+                                   zend_bool was_static, zend_bool remove_from_objects, zend_property_info *parent_property);
 
 typedef struct _zend_closure {
     zend_object    std;
@@ -442,14 +442,14 @@ struct _php_runkit_sandbox_object {
 	switch (Z_TYPE_P(pzv)) { \
 		case IS_RESOURCE: \
 		case IS_OBJECT: \
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to translate resource, or object variable to current context."); \
+			php_error_docref(NULL, E_WARNING, "Unable to translate resource, or object variable to current context."); \
 			ZVAL_NULL(pzv); \
 			break; \
 		case IS_ARRAY: \
 		{ \
 			HashTable *original_hashtable = Z_ARRVAL_P(pzv); \
 			array_init(pzv); \
-			zend_hash_apply_with_arguments(RUNKIT_53_TSRMLS_PARAM(original_hashtable), (apply_func_args_t)php_runkit_sandbox_array_deep_copy, 1, Z_ARRVAL_P(pzv) TSRMLS_CC); \
+			zend_hash_apply_with_arguments(RUNKIT_53_TSRMLS_PARAM(original_hashtable), (apply_func_args_t)php_runkit_sandbox_array_deep_copy, 1, Z_ARRVAL_P(pzv)); \
 			break; \
 		} \
 		default: \
@@ -484,11 +484,11 @@ struct _php_runkit_sandbox_object {
 	}
 
 // If lcmname is one of the magic method names(e.g. __get, __construct), then override the magic method function entry for the class entry ce (And its subclasses)
-void PHP_RUNKIT_ADD_MAGIC_METHOD(zend_class_entry *ce, zend_string* lcmname, zend_function *fe, const zend_function *orig_fe TSRMLS_DC);
+void PHP_RUNKIT_ADD_MAGIC_METHOD(zend_class_entry *ce, zend_string* lcmname, zend_function *fe, const zend_function *orig_fe);
 
 // If lcmname is one of the magic method names(e.g. __get, __construct), and being removed,
 // then override the magic method function entry for the class entry ce (And its subclasses)
-void PHP_RUNKIT_DEL_MAGIC_METHOD(zend_class_entry *ce, const zend_function *fe TSRMLS_DC);
+void PHP_RUNKIT_DEL_MAGIC_METHOD(zend_class_entry *ce, const zend_function *fe);
 
 // Sets type flags for ce and its subclasses' class entries so that the VM knows to check for magic methods.
 void ensure_all_objects_of_class_have_magic_methods(zend_class_entry *ce);
@@ -501,7 +501,7 @@ inline static zend_string* php_runkit_parse_doc_comment_arg(int argc, zval *args
 			/* Return doc comment without increasing reference count. */
 			return Z_STR(args[arg_pos]);
 		} else if (Z_TYPE(args[arg_pos]) != IS_NULL) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Doc comment should be a string or NULL");
+			php_error_docref(NULL, E_WARNING, "Doc comment should be a string or NULL");
 		}
 	}
 	return NULL;
@@ -577,14 +577,14 @@ inline static parsed_return_type php_runkit_parse_return_type_arg(int argc, zval
 			return retval;
 		}
 #if PHP_VERSION_ID >= 70100
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Return type should match regex ^\\??[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*(\\\\[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*)*$");
+		php_error_docref(NULL, E_WARNING, "Return type should match regex ^\\??[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*(\\\\[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*)*$");
 #else
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Return type should match regex ^[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*(\\\\[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*)$");
+		php_error_docref(NULL, E_WARNING, "Return type should match regex ^[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*(\\\\[a-zA-Z_\\x7f-\\xff][a-zA-Z0-9_\\x7f-\\xff]*)$");
 #endif
 		retval.valid = 0;
 		return retval;
 	} else if (Z_TYPE(args[arg_pos]) != IS_NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Return type should be a string or NULL");
+		php_error_docref(NULL, E_WARNING, "Return type should be a string or NULL");
 		retval.valid = 0;
 	}
 	return retval;
@@ -606,21 +606,21 @@ inline static parsed_is_strict php_runkit_parse_is_strict_arg(int argc, zval *ar
 		retval.overridden = 1;
 		return retval;
 	} else if (Z_TYPE(args[arg_pos]) != IS_NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "is_strict should be a boolean or NULL");
+		php_error_docref(NULL, E_WARNING, "is_strict should be a boolean or NULL");
 		retval.valid = 0;
 	}
 	return retval;
 }
 
 /* {{{ php_runkit_parse_args_to_zvals */
-inline static zend_bool php_runkit_parse_args_to_zvals(int argc, zval **pargs TSRMLS_DC) {
+inline static zend_bool php_runkit_parse_args_to_zvals(int argc, zval **pargs) {
 	*pargs = (zval *) emalloc(argc * sizeof(zval));
 	if (*pargs == NULL) {
 		PHP_RUNKIT_NOT_ENOUGH_MEMORY_ERROR;
 		return 0;
 	}
 	if (zend_get_parameters_array_ex(argc, *pargs) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Internal error occured while parsing arguments");
+		php_error_docref(NULL, E_ERROR, "Internal error occured while parsing arguments");
 		efree(*pargs);
 		return 0;
 	}
@@ -645,22 +645,22 @@ inline static zend_string* zend_string_to_interned(zend_string* original) {
 
 /* {{{ zend_bool php_runkit_parse_function_arg */
 /** Parses either multiple strings (1. function args, 2. body 3. (optional) return type), or a Closure. */
-inline static zend_bool php_runkit_parse_function_arg(int argc, zval *args, int arg_pos, zend_function **fe, zend_string** arguments, zend_string** phpcode, long *opt_arg_pos, char *type TSRMLS_DC) {
+inline static zend_bool php_runkit_parse_function_arg(int argc, zval *args, int arg_pos, zend_function **fe, zend_string** arguments, zend_string** phpcode, long *opt_arg_pos, char *type) {
 	// If is successful, it returns true, advances opt_arg_pos. There are two was this could succeed
 	// 1. *fe = zend_function extracted from a closure.
 	// 2. *arguments, *phpcode = strings extracted from arguments
 	if (Z_TYPE(args[arg_pos]) == IS_OBJECT && Z_OBJCE(args[arg_pos]) == zend_ce_closure) {
-		*fe = (zend_function *) zend_get_closure_method_def(&(args[arg_pos]) TSRMLS_CC);
+		*fe = (zend_function *) zend_get_closure_method_def(&(args[arg_pos]));
 	} else if (Z_TYPE(args[arg_pos]) == IS_STRING) {
 		(*opt_arg_pos)++;
 		*arguments = Z_STR(args[arg_pos]);
 		if (argc < arg_pos+2 || Z_TYPE(args[arg_pos+1]) != IS_STRING) {
-			php_error_docref(NULL TSRMLS_CC, E_ERROR, PHP_RUNKIT_BODY_ERROR_MSG, type);
+			php_error_docref(NULL, E_ERROR, PHP_RUNKIT_BODY_ERROR_MSG, type);
 			return 0;
 		}
 		*phpcode = Z_STR(args[arg_pos+1]);
 	} else {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, PHP_RUNKIT_BODY_ERROR_MSG, type);
+		php_error_docref(NULL, E_ERROR, PHP_RUNKIT_BODY_ERROR_MSG, type);
 		return 0;
 	}
 	return 1;
@@ -668,7 +668,7 @@ inline static zend_bool php_runkit_parse_function_arg(int argc, zval *args, int 
 /* }}} */
 
 // TODO: redundant and part of an unsupported feature
-#	define PHP_RUNKIT_DESTROY_FUNCTION(fe) 	destroy_zend_function(fe TSRMLS_CC);
+#	define PHP_RUNKIT_DESTROY_FUNCTION(fe) 	destroy_zend_function(fe);
 
 // TODO: move to a separate file.
 void php_runkit_update_reflection_object_name(zend_object* object, int handle, const char* name);
@@ -714,7 +714,7 @@ void php_runkit_update_reflection_object_name(zend_object* object, int handle, c
 #ifdef PHP_RUNKIT_SANDBOX
 // TODO: Figure out what the php7 equivalent of zend_object_store_bucket and zend_object_handle are.
 /* {{{ php_runkit_zend_object_store_get_obj */
-inline static zend_object *php_runkit_zend_object_store_get(const zval *zobject TSRMLS_DC)
+inline static zend_object *php_runkit_zend_object_store_get(const zval *zobject)
 {
 	// Note: Object handle may be removed from _zend_resource in the future.
 	int handle = Z_OBJ_HANDLE_P(zobject);

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -211,10 +211,8 @@ extern ZEND_DECLARE_MODULE_GLOBALS(runkit)
 
 #ifdef ZTS
 #define		RUNKIT_G(v)		TSRMG(runkit_globals_id, zend_runkit_globals *, v)
-#define RUNKIT_TSRMLS_C		TSRMLS_C
 #else
 #define		RUNKIT_G(v)		(runkit_globals.v)
-#define RUNKIT_TSRMLS_C		, NULL
 #endif
 
 #define RUNKIT_IS_CALLABLE(cb_zv, flags, cb_sp) zend_is_callable((cb_zv), (flags), (cb_sp))
@@ -263,7 +261,7 @@ static inline void *runkit_zend_hash_add_or_update_ptr(HashTable *ht, zend_strin
 /* runkit_functions.c */
 #define RUNKIT_TEMP_FUNCNAME  "__runkit_temporary_function__"
 int php_runkit_check_call_stack(zend_op_array *op_array);
-void php_runkit_clear_all_functions_runtime_cache(TSRMLS_D);
+void php_runkit_clear_all_functions_runtime_cache();
 void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, zend_function *called_f);
 
 void php_runkit_remove_function_from_reflection_objects(zend_function *fe);

--- a/php_runkit.h
+++ b/php_runkit.h
@@ -217,8 +217,6 @@ extern ZEND_DECLARE_MODULE_GLOBALS(runkit)
 
 #define RUNKIT_IS_CALLABLE(cb_zv, flags, cb_sp) zend_is_callable((cb_zv), (flags), (cb_sp))
 #define RUNKIT_FILE_HANDLE_DTOR(pHandle)        zend_file_handle_dtor((pHandle))
-#define RUNKIT_53_TSRMLS_PARAM(param)           (param)
-#define RUNKIT_53_TSRMLS_ARG(arg)               arg
 
 #ifdef ZEND_ACC_RETURN_REFERENCE
 #     define PHP_RUNKIT_ACC_RETURN_REFERENCE         ZEND_ACC_RETURN_REFERENCE
@@ -282,10 +280,10 @@ void php_runkit_restore_internal_function(zend_string *fname_lower, zend_functio
 /* runkit_methods.c */
 zend_class_entry *php_runkit_fetch_class(zend_string* classname);
 zend_class_entry *php_runkit_fetch_class_int(zend_string *classname);
-void php_runkit_clean_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *ce), zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_string *fname_lower, zend_function *orig_cfe);
-void php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_ARG(HashTable *ht), zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_string *fname_lower, zend_function *orig_cfe);
-void php_runkit_update_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *ce), zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_function *fe, zend_string *fname_lower, zend_function *orig_fe);
-void php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_ARG(HashTable *ht), zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_function *fe, zend_string *fname_lower, zend_function *orig_fe);
+void php_runkit_clean_children_methods(zend_class_entry *ce, zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_string *fname_lower, zend_function *orig_cfe);
+void php_runkit_clean_children_methods_foreach(HashTable *ht, zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_string *fname_lower, zend_function *orig_cfe);
+void php_runkit_update_children_methods(zend_class_entry *ce, zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_function *fe, zend_string *fname_lower, zend_function *orig_fe);
+void php_runkit_update_children_methods_foreach(HashTable *ht, zend_class_entry *ancestor_class, zend_class_entry *parent_class, zend_function *fe, zend_string *fname_lower, zend_function *orig_fe);
 int php_runkit_fetch_interface(zend_string *classname, zend_class_entry **pce);
 
 /* Redundant unless 7.1 changes - string may no longer apply */
@@ -405,7 +403,7 @@ int php_runkit_shutdown_sandbox(SHUTDOWN_FUNC_ARGS);
 /* runkit_sandbox_parent.c */
 int php_runkit_init_sandbox_parent(INIT_FUNC_ARGS);
 int php_runkit_shutdown_sandbox_parent(SHUTDOWN_FUNC_ARGS);
-int php_runkit_sandbox_array_deep_copy(RUNKIT_53_TSRMLS_ARG(zval **value), int num_args, va_list args, zend_hash_key *hash_key);
+int php_runkit_sandbox_array_deep_copy(zval **value, int num_args, va_list args, zend_hash_key *hash_key);
 
 struct _php_runkit_sandbox_object {
 	zend_object obj;
@@ -447,7 +445,7 @@ struct _php_runkit_sandbox_object {
 		{ \
 			HashTable *original_hashtable = Z_ARRVAL_P(pzv); \
 			array_init(pzv); \
-			zend_hash_apply_with_arguments(RUNKIT_53_TSRMLS_PARAM(original_hashtable), (apply_func_args_t)php_runkit_sandbox_array_deep_copy, 1, Z_ARRVAL_P(pzv)); \
+			zend_hash_apply_with_arguments(original_hashtable, (apply_func_args_t)php_runkit_sandbox_array_deep_copy, 1, Z_ARRVAL_P(pzv)); \
 			break; \
 		} \
 		default: \

--- a/php_runkit_hash.h
+++ b/php_runkit_hash.h
@@ -78,15 +78,15 @@ inline static void php_runkit_hash_move_runkit_to_front() {
 	runkit_str = zend_string_init("runkit", sizeof("runkit") - 1, 0);
 	// 1. If runkit is not part of the module registry, warn and do nothing.
 	if (!zend_hash_exists(&module_registry, runkit_str)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failed to find \"runkit\" module when attempting to change module unloading order - The lifetime of internal function overrides will be unexpected");
+		php_error_docref(NULL, E_WARNING, "Failed to find \"runkit\" module when attempting to change module unloading order - The lifetime of internal function overrides will be unexpected");
 		zend_string_release(runkit_str);
 		return;
 	}
-	// php_error_docref(NULL TSRMLS_CC, E_WARNING, "In php_runkit_hash_move_to_front size=%d", (int)zend_hash_num_elements(&module_registry));
+	// php_error_docref(NULL, E_WARNING, "In php_runkit_hash_move_to_front size=%d", (int)zend_hash_num_elements(&module_registry));
 
 	// 2. Create a temporary table with "runkit" at the front.
 	ZEND_HASH_FOREACH_KEY_PTR(&module_registry, numkey, strkey, module) {
-		// php_error_docref(NULL TSRMLS_CC, E_WARNING, "In php_runkit_hash_move_to_front numkey=%d strkey=%s refcount=%d zv=%llx", (int)numkey, strkey != NULL ? ZSTR_VAL(strkey) : "null", (int)(strkey != NULL ? zend_string_refcount(strkey) : 0), (long long) (uintptr_t)module);
+		// php_error_docref(NULL, E_WARNING, "In php_runkit_hash_move_to_front numkey=%d strkey=%s refcount=%d zv=%llx", (int)numkey, strkey != NULL ? ZSTR_VAL(strkey) : "null", (int)(strkey != NULL ? zend_string_refcount(strkey) : 0), (long long) (uintptr_t)module);
 		if (num++ == 0) {
 			zend_bool first_is_core = 0;
 			Bucket *b;
@@ -97,7 +97,7 @@ inline static void php_runkit_hash_move_runkit_to_front() {
 			if (first_is_core) {
 				zend_hash_add_ptr(&tmp, strkey, module);
 			} else {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "unexpected module order: \"core\" isn't first");
+				php_error_docref(NULL, E_WARNING, "unexpected module order: \"core\" isn't first");
 			}
 			// Otherwise, initialize the temporary table (with no destructor function)
 			b = php_runkit_zend_hash_find_bucket(&module_registry, runkit_str);

--- a/php_runkit_zval.h
+++ b/php_runkit_zval.h
@@ -22,14 +22,14 @@
 #define PHP_RUNKIT_ZVAL_H
 
 /* {{{ php_runkit_zval_resolve_class_constant */
-inline static void php_runkit_zval_resolve_class_constant(zval *p, zend_class_entry *ce TSRMLS_DC) {
+inline static void php_runkit_zval_resolve_class_constant(zval *p, zend_class_entry *ce) {
 	if (Z_CONSTANT_P(p)) {
 #if PHP_VERSION_ID >= 70100
         // TODO: What does this do?
 		// TODO: Make a copy if (Z_TYPE_FLAGS_P(p) & IS_TYPE_IMMUTABLE) != 0, test this out?
-		zval_update_constant_ex(p, ce TSRMLS_CC);
+		zval_update_constant_ex(p, ce);
 #else
-		zval_update_constant_ex(p, 1, ce TSRMLS_CC);
+		zval_update_constant_ex(p, 1, ce);
 #endif
 	}
 }

--- a/runkit_classes.c
+++ b/runkit_classes.c
@@ -106,7 +106,7 @@ PHP_FUNCTION(runkit_class_emancipate)
 		RETURN_TRUE;
 	}
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	php_runkit_remove_inherited_methods_foreach(&ce->function_table, ce);
 
@@ -288,7 +288,7 @@ PHP_FUNCTION(runkit_class_adopt)
 		}
 	} ZEND_HASH_FOREACH_END();
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	php_runkit_inherit_methods_foreach(&parent->function_table, ce);
 

--- a/runkit_classes.c
+++ b/runkit_classes.c
@@ -55,7 +55,7 @@ static int php_runkit_remove_inherited_methods(zval *pDest, void *argument)
 		return ZEND_HASH_APPLY_KEEP;
 	}
 
-	php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ancestor_class, ce, fname_lower, fe);
+	php_runkit_clean_children_methods_foreach(EG(class_table), ancestor_class, ce, fname_lower, fe);
 	PHP_RUNKIT_DEL_MAGIC_METHOD(ce, fe);
 	php_runkit_remove_function_from_reflection_objects(fe);
 
@@ -182,7 +182,7 @@ static int php_runkit_inherit_methods(zend_function *fe, zend_class_entry *ce)
 	PHP_RUNKIT_FUNCTION_ADD_REF(fe);
 	PHP_RUNKIT_ADD_MAGIC_METHOD(ce, fname_lower, fe, NULL);
 
-	php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ancestor_class, ce, fe, fname_lower, NULL);
+	php_runkit_update_children_methods_foreach(EG(class_table), ancestor_class, ce, fe, fname_lower, NULL);
 	zend_string_release(fname_lower);
 
 	return ZEND_HASH_APPLY_KEEP;

--- a/runkit_common.c
+++ b/runkit_common.c
@@ -41,7 +41,7 @@ void ensure_all_objects_of_class_have_magic_methods(zend_class_entry *ce) {
 /* }}} */
 
 /* {{{ PHP_RUNKIT_ADD_MAGIC_METHOD */
-void PHP_RUNKIT_ADD_MAGIC_METHOD(zend_class_entry *ce, zend_string* lcmname, zend_function *fe, const zend_function *orig_fe TSRMLS_DC) {
+void PHP_RUNKIT_ADD_MAGIC_METHOD(zend_class_entry *ce, zend_string* lcmname, zend_function *fe, const zend_function *orig_fe) {
 	if (zend_string_equals_literal(lcmname, ZEND_CLONE_FUNC_NAME)) {
 		(ce)->clone = (fe);
 #if PHP_VERSION_ID < 70200
@@ -73,9 +73,9 @@ void PHP_RUNKIT_ADD_MAGIC_METHOD(zend_class_entry *ce, zend_string* lcmname, zen
 		(ce)->__tostring = (fe);
 	} else if (zend_string_equals_literal(lcmname, ZEND_DEBUGINFO_FUNC_NAME)) {
 		(ce)->__debugInfo = (fe);
-	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1 TSRMLS_CC) && zend_string_equals_literal(lcmname, "serialize")) {
+	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1) && zend_string_equals_literal(lcmname, "serialize")) {
 		(ce)->serialize_func = (fe);
-	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1 TSRMLS_CC) && zend_string_equals_literal(lcmname, "unserialize")) {
+	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1) && zend_string_equals_literal(lcmname, "unserialize")) {
 		(ce)->unserialize_func = (fe);
 	} else if (zend_string_equals_ci(lcmname, (ce)->name)) {
 		// TODO: Re-examine the changes to the constructor code for any bugs.
@@ -88,7 +88,7 @@ void PHP_RUNKIT_ADD_MAGIC_METHOD(zend_class_entry *ce, zend_string* lcmname, zen
 /** }}} */
 
 /* {{{ PHP_RUNKIT_DEL_MAGIC_METHOD */
-void PHP_RUNKIT_DEL_MAGIC_METHOD(zend_class_entry *ce, const zend_function *fe TSRMLS_DC) {
+void PHP_RUNKIT_DEL_MAGIC_METHOD(zend_class_entry *ce, const zend_function *fe) {
 	if      ((ce)->constructor == (fe))       (ce)->constructor      = NULL;
 	else if ((ce)->destructor == (fe))        (ce)->destructor       = NULL;
 	else if ((ce)->__get == (fe))             (ce)->__get            = NULL;
@@ -100,9 +100,9 @@ void PHP_RUNKIT_DEL_MAGIC_METHOD(zend_class_entry *ce, const zend_function *fe T
 	else if ((ce)->__tostring == (fe))        (ce)->__tostring       = NULL;
 	else if ((ce)->__debugInfo == (fe))       (ce)->__debugInfo      = NULL;
 	else if ((ce)->clone == (fe))             (ce)->clone            = NULL;
-	else if (instanceof_function_ex(ce, zend_ce_serializable, 1 TSRMLS_CC) && (ce)->serialize_func == (fe))
+	else if (instanceof_function_ex(ce, zend_ce_serializable, 1) && (ce)->serialize_func == (fe))
 		(ce)->serialize_func   = NULL;
-	else if (instanceof_function_ex(ce, zend_ce_serializable, 1 TSRMLS_CC) && (ce)->unserialize_func == (fe))
+	else if (instanceof_function_ex(ce, zend_ce_serializable, 1) && (ce)->unserialize_func == (fe))
 		(ce)->unserialize_func = NULL;
 }
 /* }}} */

--- a/runkit_constants.c
+++ b/runkit_constants.c
@@ -288,7 +288,7 @@ void php_runkit_update_children_consts(zend_class_entry *ce, zend_class_entry *p
 	}
 
 	/* Process children of this child */
-	php_runkit_update_children_consts_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ce, value, cname RUNKIT_CONST_FLAGS_CC(access_type));
+	php_runkit_update_children_consts_foreach(EG(class_table), ce, value, cname RUNKIT_CONST_FLAGS_CC(access_type));
 
 	// TODO: Garbage collecting?
 	php_runkit_remove_from_constants_table(ce, cname);
@@ -456,7 +456,7 @@ static int php_runkit_class_constant_add(zend_string *classname, zend_string *co
 
 	// Don't add this constant to subclasses if this constant is private.
 	if (RUNKIT_CONST_FETCH(access_type) != ZEND_ACC_PRIVATE) {
-		php_runkit_update_children_consts_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ce, value, constname RUNKIT_CONST_FLAGS_CC(access_type));
+		php_runkit_update_children_consts_foreach(EG(class_table), ce, value, constname RUNKIT_CONST_FLAGS_CC(access_type));
 	}
 
 	return SUCCESS;

--- a/runkit_constants.c
+++ b/runkit_constants.c
@@ -330,7 +330,7 @@ static int php_runkit_class_constant_remove(zend_string *classname, zend_string 
 		php_error_docref(NULL, E_WARNING, "Unable to remove constant %s::%s", ZSTR_VAL(classname), ZSTR_VAL(constname));
 		return FAILURE;
 	}
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 	return SUCCESS;
 }
 /* }}}*/
@@ -356,7 +356,7 @@ static int php_runkit_global_constant_remove(zend_string *constname) {
 	}
 	efree(found_constname);
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	return SUCCESS;
 }
@@ -368,7 +368,6 @@ static int php_runkit_constant_remove(zend_string* classname, zend_string* const
 #if PHP_VERSION_ID >= 70100
 		, zend_long *old_access_type
 #endif
-		TSRMLS_DC
 		)
 {
 	if (classname && ZSTR_LEN(classname) > 0) {

--- a/runkit_functions.c
+++ b/runkit_functions.c
@@ -331,7 +331,7 @@ static void php_runkit_function_copy_ctor_same_type(zend_function *fe, zend_stri
 			HashTable *static_variables = fe->op_array.static_variables;
 			ALLOC_HASHTABLE(fe->op_array.static_variables);
 			zend_hash_init(fe->op_array.static_variables, zend_hash_num_elements(static_variables), NULL, ZVAL_PTR_DTOR, 0);
-			zend_hash_apply_with_arguments(RUNKIT_53_TSRMLS_PARAM(static_variables), zval_copy_static_var, 1, fe->op_array.static_variables);
+			zend_hash_apply_with_arguments(static_variables, zval_copy_static_var, 1, fe->op_array.static_variables);
 #endif
 		}
 

--- a/runkit_functions.c
+++ b/runkit_functions.c
@@ -665,7 +665,7 @@ static void php_runkit_clear_function_runtime_cache_for_function_table(HashTable
 /* }}} */
 
 /* {{{ php_runkit_clear_all_functions_runtime_cache */
-void php_runkit_clear_all_functions_runtime_cache(TSRMLS_D)
+void php_runkit_clear_all_functions_runtime_cache()
 {
 	uint32_t i;
 	zend_execute_data *ptr;
@@ -1196,7 +1196,7 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 		php_runkit_remove_function_from_reflection_objects(orig_fe);
 		php_runkit_destroy_misplaced_internal_function(orig_fe, funcname_lower);
 
-		php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+		php_runkit_clear_all_functions_runtime_cache();
 	}
 
 	if (runkit_zend_hash_add_or_update_function_table_ptr(EG(function_table), funcname_lower, func, add_or_update) == NULL) {
@@ -1267,7 +1267,7 @@ PHP_FUNCTION(runkit_function_remove)
 	result = (zend_hash_del(EG(function_table), fname_lower) == SUCCESS);
 	zend_string_release(fname_lower);
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	RETURN_BOOL(result);
 }
@@ -1417,7 +1417,7 @@ PHP_FUNCTION(runkit_function_rename)
 
 	zend_string_release(dfunc_lower);
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	RETURN_TRUE;
 }

--- a/runkit_functions.c
+++ b/runkit_functions.c
@@ -40,7 +40,7 @@ static void php_runkit_function_copy_ctor_same_type(zend_function *fe, zend_stri
 
 /* {{{ php_runkit_check_call_stack
  */
-int php_runkit_check_call_stack(zend_op_array *op_array TSRMLS_DC)
+int php_runkit_check_call_stack(zend_op_array *op_array)
 {
 	zend_execute_data *ptr;
 
@@ -72,7 +72,7 @@ int php_runkit_check_call_stack(zend_op_array *op_array TSRMLS_DC)
 
 /* {{{ php_runkit_fetch_function
  */
-static zend_function* php_runkit_fetch_function(zend_string* fname, int flag TSRMLS_DC)
+static zend_function* php_runkit_fetch_function(zend_string* fname, int flag)
 {
 	zend_function *fe;
 	zend_string* fname_lower;
@@ -81,21 +81,21 @@ static zend_function* php_runkit_fetch_function(zend_string* fname, int flag TSR
 
 	if ((fe = zend_hash_find_ptr(EG(function_table), fname_lower)) == NULL) {
 		zend_string_release(fname_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s() not found", ZSTR_VAL(fname));
+		php_error_docref(NULL, E_WARNING, "%s() not found", ZSTR_VAL(fname));
 		return NULL;
 	}
 
 	if (fe->type == ZEND_INTERNAL_FUNCTION &&
 		!RUNKIT_G(internal_override)) {
 		zend_string_release(fname_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s() is an internal function and runkit.internal_override is disabled", ZSTR_VAL(fname));
+		php_error_docref(NULL, E_WARNING, "%s() is an internal function and runkit.internal_override is disabled", ZSTR_VAL(fname));
 		return NULL;
 	}
 
 	if (fe->type != ZEND_USER_FUNCTION &&
 		fe->type != ZEND_INTERNAL_FUNCTION) {
 		zend_string_release(fname_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s() is not a user or normal internal function", ZSTR_VAL(fname));
+		php_error_docref(NULL, E_WARNING, "%s() is not a user or normal internal function", ZSTR_VAL(fname));
 		return NULL;
 	}
 
@@ -115,16 +115,16 @@ static zend_function* php_runkit_fetch_function(zend_string* fname, int flag TSR
 			zend_function *fe_copy;
 			// Copy over the original function - If the original function remains, it will be freed on module shutdown.
 			zend_string_addref(fe->common.function_name);  // possibly unnecessary
-			fe_copy = php_runkit_function_clone(fe, fe->common.function_name, ZEND_INTERNAL_FUNCTION TSRMLS_CC);
+			fe_copy = php_runkit_function_clone(fe, fe->common.function_name, ZEND_INTERNAL_FUNCTION);
 			// Copy over the original persistent string - That string wouldn't be destroyed on request shutdown in fpm, and can be reused in future requests?
 			b = php_runkit_zend_hash_find_bucket(EG(function_table), fname_lower);
-			// php_error_docref(NULL TSRMLS_CC, E_WARNING, "Finding persistent string %s: %llx\n", ZSTR_VAL(fname_lower), (long long)(uintptr_t)b);
+			// php_error_docref(NULL, E_WARNING, "Finding persistent string %s: %llx\n", ZSTR_VAL(fname_lower), (long long)(uintptr_t)b);
 			// It's a persistent string, not an interned string? Is it always a persistent string (E.g. in NTS, ZTS, maintainer ZTS)?
 			if (b->key != NULL) {
 				zend_string_addref(b->key);
 				zend_string_release(fname_lower);
 				fname_lower = b->key;
-				// php_error_docref(NULL TSRMLS_CC, E_WARNING, "Stealing persistent string %s\n", ZSTR_VAL(fname_lower));
+				// php_error_docref(NULL, E_WARNING, "Stealing persistent string %s\n", ZSTR_VAL(fname_lower));
 			} else {
 				zend_string_addref(fname_lower);
 			}
@@ -154,7 +154,7 @@ static inline void php_runkit_ensure_misplaced_internal_functions_table_exists()
 /* }}} */
 
 /* {{{ php_runkit_add_to_misplaced_internal_functions */
-static inline void php_runkit_add_to_misplaced_internal_functions(zend_function *fe, zend_string *name_lower TSRMLS_DC) {
+static inline void php_runkit_add_to_misplaced_internal_functions(zend_function *fe, zend_string *name_lower) {
 	if (fe->type == ZEND_INTERNAL_FUNCTION &&
 	    (!RUNKIT_G(misplaced_internal_functions) ||
 	     !zend_hash_exists(RUNKIT_G(misplaced_internal_functions), name_lower))
@@ -170,7 +170,7 @@ static inline void php_runkit_add_to_misplaced_internal_functions(zend_function 
 /* }}} */
 
 /* {{{ php_runkit_destroy_misplaced_internal_function */
-static inline void php_runkit_destroy_misplaced_internal_function(zend_function *fe, zend_string *fname_lower TSRMLS_DC) {
+static inline void php_runkit_destroy_misplaced_internal_function(zend_function *fe, zend_string *fname_lower) {
 	if (fe->type == ZEND_INTERNAL_FUNCTION && RUNKIT_G(misplaced_internal_functions) &&
 	    zend_hash_exists(RUNKIT_G(misplaced_internal_functions), fname_lower)) {
 		// PHP_RUNKIT_FREE_INTERNAL_FUNCTION_NAME would have been called, but function destructor already deletes those?
@@ -268,7 +268,7 @@ static void php_runkit_function_create_alias_internal_function(zend_function *fe
 /* {{{ php_runkit_function_copy_ctor
 	Duplicate structures in a zend_function where necessary to make an outright duplicate.
 	Does additional work to ensure that the type of the final function is orig_fe_type. */
-int php_runkit_function_copy_ctor(zend_function *fe, zend_string* newname, char orig_fe_type TSRMLS_DC)
+int php_runkit_function_copy_ctor(zend_function *fe, zend_string* newname, char orig_fe_type)
 {
 	if (fe->type == orig_fe_type) {
 		php_runkit_function_copy_ctor_same_type(fe, newname);
@@ -508,7 +508,7 @@ static void php_runkit_function_copy_ctor_same_type(zend_function *fe, zend_stri
 /* {{{ php_runkit_function_clone
    Makes a duplicate of fe that doesn't share any static variables, zvals, etc.
    TODO: Is there anything I can use from zend_duplicate_function? */
-zend_function* php_runkit_function_clone(zend_function *fe, zend_string *newname, char orig_fe_type TSRMLS_DC) {
+zend_function* php_runkit_function_clone(zend_function *fe, zend_string *newname, char orig_fe_type) {
 	// Make a persistent allocation.
 	// TODO: Clean it up after a request?
 	zend_function *new_function = pemalloc(sizeof(zend_function), 1);
@@ -518,7 +518,7 @@ zend_function* php_runkit_function_clone(zend_function *fe, zend_string *newname
 	} else {
 		memcpy(new_function, fe, sizeof(zend_function));
 	}
-	php_runkit_function_copy_ctor(new_function, newname, orig_fe_type TSRMLS_CC);
+	php_runkit_function_copy_ctor(new_function, newname, orig_fe_type);
 	return new_function;
 }
 /* }}} */
@@ -540,7 +540,7 @@ void php_runkit_free_inner_if_aliased_function(zend_function *fe) {
 }
 
 /* {{{ php_runkit_function_dtor_impl - Destroys functions, handles special fields added if they're from runkit. */
-void php_runkit_function_dtor_impl(zend_function *fe, zend_bool is_clone TSRMLS_DC) {
+void php_runkit_function_dtor_impl(zend_function *fe, zend_bool is_clone) {
 	zval zv;
 	zend_bool is_user_function;
 	is_user_function = fe->type == ZEND_USER_FUNCTION;
@@ -556,15 +556,15 @@ void php_runkit_function_dtor_impl(zend_function *fe, zend_bool is_clone TSRMLS_
 /* }}} */
 
 /* {{{ php_runkit_function_dtor - Only to be used if we are sure this was created by runkit with runkit_function_clone. */
-void php_runkit_function_dtor(zend_function *fe TSRMLS_DC) {
-	php_runkit_function_dtor_impl(fe, 1 TSRMLS_CC);
+void php_runkit_function_dtor(zend_function *fe) {
+	php_runkit_function_dtor_impl(fe, 1);
 }
 /* }}} */
 
 // The original destructor of the affected function_table.
 static dtor_func_t __function_table_orig_pDestructor = NULL;
 
-static void php_runkit_function_table_dtor(zval *pDest TSRMLS_DC) {
+static void php_runkit_function_table_dtor(zval *pDest) {
 	zend_function *fe = (zend_function*)Z_PTR_P(pDest);
 	if (RUNKIT_IS_ALIAS_FOR_USER_FUNCTION(fe)) {
 		php_runkit_free_inner_if_aliased_function(fe);
@@ -725,7 +725,7 @@ static inline void php_runkit_fix_hardcoded_stack_sizes(zend_function *f, zend_s
 			//printf("Checking init_fcall, function name = %s\n", ZSTR_VAL(Z_STR_P(function_name)));
 			if (zend_string_equals(Z_STR_P(function_name), called_name_lower)) {
 				// Modify that opline with the recalculated required stack size
-				uint32_t new_size = zend_vm_calc_used_stack(it->extended_value, called_f TSRMLS_CC);
+				uint32_t new_size = zend_vm_calc_used_stack(it->extended_value, called_f);
 				if (new_size > it->op1.num) {
 					it->op1.num = new_size;
 				}
@@ -745,16 +745,16 @@ static void php_runkit_fix_hardcoded_stack_sizes_for_function_table(HashTable *f
 /* }}} */
 
 /* {{{ php_runkit_fix_hardcoded_stack_sizes */
-void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, zend_function *called_f TSRMLS_DC)
+void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, zend_function *called_f)
 {
 	uint32_t i;
 	zend_class_entry* ce;
 	zend_execute_data *ptr;
 
-	php_runkit_fix_hardcoded_stack_sizes_for_function_table(EG(function_table), called_name_lower, called_f TSRMLS_CC);
+	php_runkit_fix_hardcoded_stack_sizes_for_function_table(EG(function_table), called_name_lower, called_f);
 
 	ZEND_HASH_FOREACH_PTR(EG(class_table), ce) {
-		php_runkit_fix_hardcoded_stack_sizes_for_function_table(&(ce->function_table), called_name_lower, called_f TSRMLS_CC);
+		php_runkit_fix_hardcoded_stack_sizes_for_function_table(&(ce->function_table), called_name_lower, called_f);
 	} ZEND_HASH_FOREACH_END();
 
 	// This is also needed to get the top-level {main} script, which isn't in the function table
@@ -764,13 +764,13 @@ void php_runkit_fix_all_hardcoded_stack_sizes(zend_string *called_name_lower, ze
 		if (ptr->func == NULL || ptr->func->type != ZEND_USER_FUNCTION) {
 			continue;
 		}
-		php_runkit_fix_hardcoded_stack_sizes(ptr->func, called_name_lower, called_f TSRMLS_CC);
+		php_runkit_fix_hardcoded_stack_sizes(ptr->func, called_name_lower, called_f);
 	}
 
 	PHP_RUNKIT_ITERATE_THROUGH_OBJECTS_STORE_BEGIN(i)
 		if (object->ce == zend_ce_closure) {
 			zend_closure *cl = (zend_closure *) object;
-			php_runkit_fix_hardcoded_stack_sizes(&cl->func, called_name_lower, called_f TSRMLS_CC);
+			php_runkit_fix_hardcoded_stack_sizes(&cl->func, called_name_lower, called_f);
 		}
 	PHP_RUNKIT_ITERATE_THROUGH_OBJECTS_STORE_END
 }
@@ -817,7 +817,7 @@ static inline reflection_object *reflection_object_from_obj(zend_object *obj) {
 
 /* {{{ php_runkit_delete_reflection_function_ptr
  	Frees the parts of a reflection object referring to the removed method/function(/parameter?)  */
-static void php_runkit_delete_reflection_function_ptr(reflection_object *intern TSRMLS_DC) {
+static void php_runkit_delete_reflection_function_ptr(reflection_object *intern) {
 	// Copied from ext/reflection's reflection_free_objects_storage
 	parameter_reference *reference;
 	if (intern->ptr) {
@@ -834,7 +834,7 @@ static void php_runkit_delete_reflection_function_ptr(reflection_object *intern 
 				efree(intern->ptr);
 				break;
 			default:
-				php_error_docref(NULL TSRMLS_CC, E_ERROR, "Attempted to free ReflectionObject of unexpected REF_TYPE %d\n", (int) (intern->ref_type));
+				php_error_docref(NULL, E_ERROR, "Attempted to free ReflectionObject of unexpected REF_TYPE %d\n", (int) (intern->ref_type));
 				return;
 		}
 	}
@@ -844,7 +844,7 @@ static void php_runkit_delete_reflection_function_ptr(reflection_object *intern 
 /* }}}*/
 
 /* {{{ php_runkit_remove_function_from_reflection_objects */
-void php_runkit_remove_function_from_reflection_objects(zend_function *fe TSRMLS_DC) {
+void php_runkit_remove_function_from_reflection_objects(zend_function *fe) {
 	uint32_t i;
 	extern PHPAPI zend_class_entry *reflection_function_ptr;
 	extern PHPAPI zend_class_entry *reflection_method_ptr;
@@ -889,7 +889,7 @@ void php_runkit_remove_function_from_reflection_objects(zend_function *fe TSRMLS
     Heavily borrowed from ZEND_FUNCTION(create_function).
     Used by runkit_function_add and runkit_function_redefine. Also see php_runkit_generate_lambda_method. */
 int php_runkit_generate_lambda_function(const zend_string *arguments, const zend_string *return_type, const zend_bool is_strict, const zend_string *phpcode,
-                                        zend_function **pfe, zend_bool return_ref TSRMLS_DC)
+                                        zend_function **pfe, zend_bool return_ref)
 {
 	char *eval_code;
 	char *eval_name;
@@ -916,9 +916,9 @@ int php_runkit_generate_lambda_function(const zend_string *arguments, const zend
 	// I don't believe that that option changes the opcodes, so copy() can work.
 	eval_code = (char*)emalloc(eval_code_length);
 	snprintf(eval_code, eval_code_length, "%sfunction %s" RUNKIT_TEMP_FUNCNAME "(%s)%s{%s}", is_strict ? "declare(strict_types=1);" : "", (return_ref ? "&" : ""), ZSTR_VAL(arguments), return_type_code, ZSTR_VAL(phpcode));
-	eval_name = zend_make_compiled_string_description("runkit runtime-created function" TSRMLS_CC);
-	if (zend_eval_string(eval_code, NULL, eval_name TSRMLS_CC) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Cannot create temporary function '%s'", eval_code);
+	eval_name = zend_make_compiled_string_description("runkit runtime-created function");
+	if (zend_eval_string(eval_code, NULL, eval_name) == FAILURE) {
+		php_error_docref(NULL, E_ERROR, "Cannot create temporary function '%s'", eval_code);
 		efree(eval_code);
 		efree(eval_name);
 		efree(return_type_code);
@@ -930,7 +930,7 @@ int php_runkit_generate_lambda_function(const zend_string *arguments, const zend
 	efree(return_type_code);
 
 	if ((*pfe = zend_hash_str_find_ptr(EG(function_table), RUNKIT_TEMP_FUNCNAME, sizeof(RUNKIT_TEMP_FUNCNAME) - 1)) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Unexpected inconsistency creating temporary runkit function");
+		php_error_docref(NULL, E_ERROR, "Unexpected inconsistency creating temporary runkit function");
 		return FAILURE;
 	}
 
@@ -942,7 +942,7 @@ int php_runkit_generate_lambda_function(const zend_string *arguments, const zend
 	Used by runkit_method_add and runkit_method_redefine. Also see php_runkit_generate_lambda_function. */
 int php_runkit_generate_lambda_method(const zend_string *arguments, const zend_string *return_type, const zend_bool is_strict, const zend_string *phpcode,
 
-                                        zend_function **pfe, zend_bool return_ref, zend_bool is_static TSRMLS_DC)
+                                        zend_function **pfe, zend_bool return_ref, zend_bool is_static)
 {
 	char *eval_code;
 	char *eval_name;
@@ -978,12 +978,12 @@ int php_runkit_generate_lambda_method(const zend_string *arguments, const zend_s
 			ZSTR_VAL(arguments),
 			return_type_code,
 			ZSTR_VAL(phpcode));
-	eval_name = zend_make_compiled_string_description("runkit runtime-created method" TSRMLS_CC);
-	if (zend_eval_string(eval_code, NULL, eval_name TSRMLS_CC) == FAILURE) {
+	eval_name = zend_make_compiled_string_description("runkit runtime-created method");
+	if (zend_eval_string(eval_code, NULL, eval_name) == FAILURE) {
 		efree(eval_code);
 		efree(eval_name);
 		efree(return_type_code);
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Cannot create temporary method");
+		php_error_docref(NULL, E_ERROR, "Cannot create temporary method");
 		zend_hash_str_del(EG(class_table), RUNKIT_TEMP_CLASSNAME, sizeof(RUNKIT_TEMP_CLASSNAME) - 1);
 		return FAILURE;
 	}
@@ -993,12 +993,12 @@ int php_runkit_generate_lambda_method(const zend_string *arguments, const zend_s
 
 	ce = zend_hash_str_find_ptr(EG(class_table), RUNKIT_TEMP_CLASSNAME, sizeof(RUNKIT_TEMP_CLASSNAME) - 1);
 	if (ce == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Unexpected inconsistency creating a temporary class");
+		php_error_docref(NULL, E_ERROR, "Unexpected inconsistency creating a temporary class");
 		return FAILURE;
 	}
 
 	if ((*pfe = zend_hash_str_find_ptr(&(ce->function_table), RUNKIT_TEMP_METHODNAME, sizeof(RUNKIT_TEMP_METHODNAME) - 1)) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Unexpected inconsistency creating a temporary method");
+		php_error_docref(NULL, E_ERROR, "Unexpected inconsistency creating a temporary method");
 	}
 
 	return SUCCESS;
@@ -1011,7 +1011,7 @@ int php_runkit_generate_lambda_method(const zend_string *arguments, const zend_s
 	If it fails, emits a warning and returns FAILURE.  */
 int php_runkit_cleanup_lambda_function() {
 	if (zend_hash_str_del(EG(function_table), RUNKIT_TEMP_FUNCNAME, sizeof(RUNKIT_TEMP_FUNCNAME) - 1) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to remove temporary function entry");
+		php_error_docref(NULL, E_WARNING, "Unable to remove temporary function entry");
 		return FAILURE;
 	}
 	return SUCCESS;
@@ -1023,7 +1023,7 @@ int php_runkit_cleanup_lambda_function() {
 	If it fails, emits a warning and returns FAILURE.  */
 int php_runkit_cleanup_lambda_method() {
 	if (zend_hash_str_del(EG(class_table), RUNKIT_TEMP_CLASSNAME, sizeof(RUNKIT_TEMP_CLASSNAME) - 1) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to remove temporary method entry");
+		php_error_docref(NULL, E_WARNING, "Unable to remove temporary method entry");
 		return FAILURE;
 	}
 	return SUCCESS;
@@ -1033,7 +1033,7 @@ int php_runkit_cleanup_lambda_method() {
 /* {{{ php_runkit_destroy_misplaced_functions
 	Wipe old internal functions that were renamed to new targets
 	They'll get replaced soon enough */
-int php_runkit_destroy_misplaced_functions(zval *zv TSRMLS_DC)
+int php_runkit_destroy_misplaced_functions(zval *zv)
 {
 	// zend_function *fe;
 	if (Z_TYPE_P(zv) != IS_STRING || Z_STRLEN_P(zv) == 0) {
@@ -1062,7 +1062,7 @@ void php_runkit_restore_internal_function(zend_string *fname_lower, zend_functio
 		return;
 	}
 	php_runkit_update_ptr_in_function_table(EG(function_table), fname_lower, f);
-	// php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s() exists: %d", ZSTR_VAL(fname_lower), (int)(zend_hash_exists(EG(function_table), fname_lower) ? 1 : 0));
+	// php_error_docref(NULL, E_WARNING, "%s() exists: %d", ZSTR_VAL(fname_lower), (int)(zend_hash_exists(EG(function_table), fname_lower) ? 1 : 0));
 
 	// NOTE: moving to the front of the hash seems to be unnecessary in php 7 - Entries of function_table are removed with plain zend_hash_del
 	/* It's possible for restored internal functions to now be blocking a ZEND_USER_FUNCTION
@@ -1090,21 +1090,21 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 	long argc = ZEND_NUM_ARGS();
 	long opt_arg_pos = 2;
 
-	if (argc < 1 || zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, 1 TSRMLS_CC, "S", &funcname) == FAILURE || !ZSTR_LEN(funcname)) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Function name should not be empty");
+	if (argc < 1 || zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, 1, "S", &funcname) == FAILURE || !ZSTR_LEN(funcname)) {
+		php_error_docref(NULL, E_ERROR, "Function name should not be empty");
 		RETURN_FALSE;
 	}
 
 	if (argc < 2) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Function body should be provided");
+		php_error_docref(NULL, E_ERROR, "Function body should be provided");
 		RETURN_FALSE;
 	}
 
-	if (!php_runkit_parse_args_to_zvals(argc, &args TSRMLS_CC)) {
+	if (!php_runkit_parse_args_to_zvals(argc, &args)) {
 		RETURN_FALSE;
 	}
 
-	if (!php_runkit_parse_function_arg(argc, args, 1, &source_fe, &arguments, &phpcode, &opt_arg_pos, "Function" TSRMLS_CC)) {
+	if (!php_runkit_parse_function_arg(argc, args, 1, &source_fe, &arguments, &phpcode, &opt_arg_pos, "Function")) {
 		efree(args);
 		RETURN_FALSE;
 	}
@@ -1118,7 +1118,7 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 				return_ref = Z_TYPE(args[opt_arg_pos]) == IS_TRUE;
 				break;
 			default:
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "return_ref should be boolean");
+				php_error_docref(NULL, E_WARNING, "return_ref should be boolean");
 		}
 		opt_arg_pos++;
 	}
@@ -1139,17 +1139,17 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 
 	if (source_fe && return_type.return_type) {
 		// TODO: Check what needs to be needs to be changed in opcode array if return_type is changed
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Overriding return_type is not currently supported for closures, use return type in closure definition instead (or pass in code as string)");
+		php_error_docref(NULL, E_WARNING, "Overriding return_type is not currently supported for closures, use return type in closure definition instead (or pass in code as string)");
 		RETURN_FALSE;
 	}
 	if (source_fe && is_strict.overridden) {
 		// TODO: Check what needs to be needs to be changed in opcode array if is_strict is changed
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Overriding is_strict is not currently supported for closures (pass in code as string)");
+		php_error_docref(NULL, E_WARNING, "Overriding is_strict is not currently supported for closures (pass in code as string)");
 		RETURN_FALSE;
 	}
 
 	if (add_or_update == HASH_UPDATE &&
-	    (orig_fe = php_runkit_fetch_function(funcname, PHP_RUNKIT_FETCH_FUNCTION_REMOVE TSRMLS_CC)) == NULL) {
+	    (orig_fe = php_runkit_fetch_function(funcname, PHP_RUNKIT_FETCH_FUNCTION_REMOVE)) == NULL) {
 		RETURN_FALSE;
 	}
 
@@ -1158,12 +1158,12 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 
 	if (add_or_update == HASH_ADD && zend_hash_exists(EG(function_table), funcname_lower)) {
 		zend_string_release(funcname_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Function %s() already exists", ZSTR_VAL(funcname));
+		php_error_docref(NULL, E_WARNING, "Function %s() already exists", ZSTR_VAL(funcname));
 		RETURN_FALSE;
 	}
 
 	if (!source_fe) {
-		if (php_runkit_generate_lambda_function(arguments, return_type.return_type, is_strict.is_strict, phpcode, &source_fe, return_ref TSRMLS_CC) == FAILURE) {
+		if (php_runkit_generate_lambda_function(arguments, return_type.return_type, is_strict.is_strict, phpcode, &source_fe, return_ref) == FAILURE) {
 			zend_string_release(funcname_lower);
 			RETURN_FALSE;
 		}
@@ -1178,7 +1178,7 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 		target_function_type = RUNKIT_G(replaced_internal_functions)
 			&& zend_hash_exists(RUNKIT_G(replaced_internal_functions), funcname_lower) ? ZEND_INTERNAL_FUNCTION : ZEND_USER_FUNCTION;
 	}
-	func = php_runkit_function_clone(source_fe, funcname, target_function_type TSRMLS_CC);
+	func = php_runkit_function_clone(source_fe, funcname, target_function_type);
 	//printf("Func function->handler = %llx, op=%s\n", source_fe->type == ZEND_USER_FUNCTION ? (long long)source_fe->internal_function.handler : 0, add_or_update == HASH_ADD ? "add" : "update");
 	func->common.scope = NULL;
 	func->common.fn_flags &= ~ZEND_ACC_CLOSURE;
@@ -1190,17 +1190,17 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 	php_runkit_modify_function_doc_comment(func, doc_comment);
 
 	/* When redefining or adding a function (which may have been removed before), update the stack sizes it will be called with. */
-	php_runkit_fix_all_hardcoded_stack_sizes(funcname_lower, func TSRMLS_CC);
+	php_runkit_fix_all_hardcoded_stack_sizes(funcname_lower, func);
 
 	if (add_or_update == HASH_UPDATE) {
-		php_runkit_remove_function_from_reflection_objects(orig_fe TSRMLS_CC);
-		php_runkit_destroy_misplaced_internal_function(orig_fe, funcname_lower TSRMLS_CC);
+		php_runkit_remove_function_from_reflection_objects(orig_fe);
+		php_runkit_destroy_misplaced_internal_function(orig_fe, funcname_lower);
 
 		php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 	}
 
 	if (runkit_zend_hash_add_or_update_function_table_ptr(EG(function_table), funcname_lower, func, add_or_update) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to add new function");
+		php_error_docref(NULL, E_WARNING, "Unable to add new function");
 		zend_string_release(funcname_lower);
 		if (remove_temp) {
 			php_runkit_cleanup_lambda_function();
@@ -1216,7 +1216,7 @@ static void php_runkit_function_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int 
 
 	if (zend_hash_find(EG(function_table), funcname_lower) == NULL) {
 		// TODO: || !fe - what did that do?
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate newly added function");
+		php_error_docref(NULL, E_WARNING, "Unable to locate newly added function");
 		zend_string_release(funcname_lower);
 		RETURN_FALSE;
 	}
@@ -1250,19 +1250,19 @@ PHP_FUNCTION(runkit_function_remove)
 	int result;
 	zend_function *fe;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "S", &fname) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &fname) == FAILURE) {
 		RETURN_FALSE;
 	}
 
 	// TODO what?
-	if ((fe = php_runkit_fetch_function(fname, PHP_RUNKIT_FETCH_FUNCTION_REMOVE TSRMLS_CC)) == NULL) {
+	if ((fe = php_runkit_fetch_function(fname, PHP_RUNKIT_FETCH_FUNCTION_REMOVE)) == NULL) {
 		RETURN_FALSE;
 	}
 
 	fname_lower = zend_string_tolower(fname);
 
-	php_runkit_remove_function_from_reflection_objects(fe TSRMLS_CC);
-	php_runkit_destroy_misplaced_internal_function(fe, fname_lower TSRMLS_CC);
+	php_runkit_remove_function_from_reflection_objects(fe);
+	php_runkit_destroy_misplaced_internal_function(fe, fname_lower);
 
 	result = (zend_hash_del(EG(function_table), fname_lower) == SUCCESS);
 	zend_string_release(fname_lower);
@@ -1280,7 +1280,7 @@ PHP_FUNCTION(runkit_function_remove)
 	zend_string *sfunc_lower; \
 	zend_string *dfunc_lower; \
 	\
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, \
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), \
 			"SS", \
 			&sfunc, \
 			&dfunc) == FAILURE ) { \
@@ -1292,7 +1292,7 @@ PHP_FUNCTION(runkit_function_remove)
 	\
 	if (zend_hash_exists(EG(function_table), dfunc_lower)) { \
 		zend_string_release(dfunc_lower); \
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s() already exists", ZSTR_VAL(dfunc)); \
+		php_error_docref(NULL, E_WARNING, "%s() already exists", ZSTR_VAL(dfunc)); \
 		RETURN_FALSE; \
 	}
 /* }}} */
@@ -1329,15 +1329,15 @@ PHP_FUNCTION(runkit_function_rename)
 	// Check if the destination function already exists, and create strings for function names.
 	PHP_RUNKIT_FUNCTION_PARSE_RENAME_COPY_PARAMS;
 
-	if ((sfe = php_runkit_fetch_function(sfunc, PHP_RUNKIT_FETCH_FUNCTION_RENAME TSRMLS_CC)) == NULL) {
+	if ((sfe = php_runkit_fetch_function(sfunc, PHP_RUNKIT_FETCH_FUNCTION_RENAME)) == NULL) {
 		zend_string_release(dfunc_lower);
 		RETURN_FALSE;
 	}
 
 	sfunc_lower = zend_string_tolower(sfunc);
 
-	php_runkit_remove_function_from_reflection_objects(sfe TSRMLS_CC);
-	php_runkit_destroy_misplaced_internal_function(sfe, sfunc_lower TSRMLS_CC);
+	php_runkit_remove_function_from_reflection_objects(sfe);
+	php_runkit_destroy_misplaced_internal_function(sfe, sfunc_lower);
 
 	// TODO: Should I use clone instead?
 	// This may cause errors.
@@ -1371,7 +1371,7 @@ PHP_FUNCTION(runkit_function_rename)
 	} else {
 		// TODO: Will need to check for user functions that are aliases of internal functions, once that is implemented.
 		should_invoke_dtor_on_original = 1;
-		func = php_runkit_function_clone(sfe, dfunc, orig_dfunc_type TSRMLS_CC);
+		func = php_runkit_function_clone(sfe, dfunc, orig_dfunc_type);
 	}
 
 	if (should_invoke_dtor_on_original) {
@@ -1387,7 +1387,7 @@ PHP_FUNCTION(runkit_function_rename)
 	if (deleted) {
 		zend_string_release(dfunc_lower);
 		zend_string_release(sfunc_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error removing reference to old function name %s()", ZSTR_VAL(sfunc));
+		php_error_docref(NULL, E_WARNING, "Error removing reference to old function name %s()", ZSTR_VAL(sfunc));
 		PHP_RUNKIT_FREE_INTERNAL_FUNCTION_NAME(func);
 		/* TODO: is this needed?
 		ZVAL_FUNC(&tmpVal, &func);
@@ -1399,7 +1399,7 @@ PHP_FUNCTION(runkit_function_rename)
 
 	if (zend_hash_add_ptr(EG(function_table), dfunc_lower, func) == NULL) {
 		zend_string_release(dfunc_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to add reference to new function name %s()", ZSTR_VAL(dfunc));
+		php_error_docref(NULL, E_WARNING, "Unable to add reference to new function name %s()", ZSTR_VAL(dfunc));
 		// TODO: Figure out if this is needed?
 		PHP_RUNKIT_FREE_INTERNAL_FUNCTION_NAME(func);
 		// TODO: I'm not sure if this line will delete the zvals/strings of the original function,
@@ -1439,7 +1439,7 @@ PHP_FUNCTION(runkit_function_copy)
 	zend_function *fe, *sfe;
 	PHP_RUNKIT_FUNCTION_PARSE_RENAME_COPY_PARAMS;
 
-	if ((sfe = php_runkit_fetch_function(sfunc, PHP_RUNKIT_FETCH_FUNCTION_INSPECT TSRMLS_CC)) == NULL) {
+	if ((sfe = php_runkit_fetch_function(sfunc, PHP_RUNKIT_FETCH_FUNCTION_INSPECT)) == NULL) {
 		zend_string_release(dfunc_lower);
 		RETURN_FALSE;
 	}
@@ -1448,7 +1448,7 @@ PHP_FUNCTION(runkit_function_copy)
 
 	if (sfe->type == ZEND_USER_FUNCTION) {
 		// Copy a user function to a user function
-		fe = php_runkit_function_clone(sfe, dfunc, ZEND_USER_FUNCTION TSRMLS_CC);
+		fe = php_runkit_function_clone(sfe, dfunc, ZEND_USER_FUNCTION);
 	} else {
 		record_misplaced_internal_function(dfunc_lower);
 		// FIXME copying an internal function to a user function.
@@ -1461,14 +1461,14 @@ PHP_FUNCTION(runkit_function_copy)
 		zend_string_addref(fe->common.function_name);
 		zend_string_addref(fe->common.function_name);
 	}
-	php_runkit_add_to_misplaced_internal_functions(fe, dfunc_lower TSRMLS_CC);
+	php_runkit_add_to_misplaced_internal_functions(fe, dfunc_lower);
 
 	// TODO: Does this even make sense to add?
 
 	if (zend_hash_add_ptr(EG(function_table), dfunc_lower, fe) == NULL) {
 		zend_string_release(dfunc_lower);
 		zend_string_release(sfunc_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to add reference to new function name %s()", ZSTR_VAL(dfunc));
+		php_error_docref(NULL, E_WARNING, "Unable to add reference to new function name %s()", ZSTR_VAL(dfunc));
 		// TODO: figure out if this is necessary
 		PHP_RUNKIT_FREE_INTERNAL_FUNCTION_NAME(fe);
 		php_runkit_function_dtor(fe);

--- a/runkit_import.c
+++ b/runkit_import.c
@@ -31,8 +31,7 @@
 /* {{{ php_runkit_import_functions
  */
 static int php_runkit_import_functions(HashTable *function_table, long flags
-                                       , zend_bool *clear_cache
-                                       TSRMLS_DC)
+                                       , zend_bool *clear_cache)
 {
 	zend_function *fe;
 	zend_ulong idx;
@@ -111,8 +110,7 @@ static int php_runkit_import_functions(HashTable *function_table, long flags
 /* {{{ php_runkit_import_class_methods
  */
 static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_entry *ce, int override
-                                           , zend_bool *clear_cache
-                                           TSRMLS_DC)
+                                           , zend_bool *clear_cache)
 {
 	zend_function *fe;
 
@@ -342,8 +340,7 @@ static int php_runkit_import_class_props(zend_class_entry *dce, zend_class_entry
 /* {{{ php_runkit_import_classes
  */
 static int php_runkit_import_classes(HashTable *class_table, const long flags
-                                     , zend_bool *clear_cache
-                                     TSRMLS_DC)
+                                     , zend_bool *clear_cache)
 {
 	zval *ce_zv;
 	zend_string *key;
@@ -400,20 +397,17 @@ static int php_runkit_import_classes(HashTable *class_table, const long flags
 			}
 			if (flags & PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS) {
 				php_runkit_import_class_static_props(dce, ce, (flags & PHP_RUNKIT_IMPORT_OVERRIDE) != 0,
-				                                     (flags & PHP_RUNKIT_OVERRIDE_OBJECTS) != 0
-				                                     TSRMLS_CC);
+				                                     (flags & PHP_RUNKIT_OVERRIDE_OBJECTS) != 0);
 			}
 
 			if (flags & PHP_RUNKIT_IMPORT_CLASS_PROPS) {
 				php_runkit_import_class_props(dce, ce, (flags & PHP_RUNKIT_IMPORT_OVERRIDE) != 0,
-				                              (flags & PHP_RUNKIT_OVERRIDE_OBJECTS) != 0
-				                              TSRMLS_CC);
+				                              (flags & PHP_RUNKIT_OVERRIDE_OBJECTS) != 0);
 			}
 
 			if (flags & PHP_RUNKIT_IMPORT_CLASS_METHODS) {
 				php_runkit_import_class_methods(dce, ce, flags & (PHP_RUNKIT_IMPORT_OVERRIDE)
-				                                , clear_cache
-				                                TSRMLS_CC);
+				                                , clear_cache);
 			}
 		}
 	} ZEND_HASH_FOREACH_END();
@@ -622,7 +616,7 @@ PHP_FUNCTION(runkit_import)
 	efree(tmp_function_table);
 
 	if (clear_cache) {
-		php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+		php_runkit_clear_all_functions_runtime_cache();
 	}
 
 	RETURN_TRUE;

--- a/runkit_import.c
+++ b/runkit_import.c
@@ -61,19 +61,19 @@ static int php_runkit_import_functions(HashTable *function_table, long flags
 		if (exists) {
 			create_as_internal = orig_fe->type == ZEND_INTERNAL_FUNCTION;
 			if (create_as_internal && !RUNKIT_G(internal_override)) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s() is an internal function and runkit.internal_override is disabled", ZSTR_VAL(new_key));
+				php_error_docref(NULL, E_WARNING, "%s() is an internal function and runkit.internal_override is disabled", ZSTR_VAL(new_key));
 				continue;
 			}
-			php_runkit_remove_function_from_reflection_objects(orig_fe TSRMLS_CC);
+			php_runkit_remove_function_from_reflection_objects(orig_fe);
 			if (flags & PHP_RUNKIT_IMPORT_OVERRIDE) {
 				if (key != NULL) {
 					if (zend_hash_del(EG(function_table), new_key) == FAILURE) {
-						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Inconsistency cleaning up import environment");
+						php_error_docref(NULL, E_WARNING, "Inconsistency cleaning up import environment");
 						return FAILURE;
 					}
 				} else {
 					if (zend_hash_index_del(EG(function_table), idx) == FAILURE) {
-						php_error_docref(NULL TSRMLS_CC, E_WARNING, "Inconsistency cleaning up import environment");
+						php_error_docref(NULL, E_WARNING, "Inconsistency cleaning up import environment");
 						return FAILURE;
 					}
 				}
@@ -89,7 +89,7 @@ static int php_runkit_import_functions(HashTable *function_table, long flags
 				add_fe = php_runkit_function_clone(fe, new_key, ZEND_INTERNAL_FUNCTION);
 			}
 			if (zend_hash_add_ptr(EG(function_table), new_key, add_fe) == NULL) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure importing %s()", ZSTR_VAL(add_fe->common.function_name));
+				php_error_docref(NULL, E_WARNING, "Failure importing %s()", ZSTR_VAL(add_fe->common.function_name));
 				if (add_fe != fe) {
 					PHP_RUNKIT_DESTROY_FUNCTION(add_fe);
 				}
@@ -134,15 +134,15 @@ static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_ent
 		if (dfe != NULL) {
 			zend_class_entry *scope;
 			if (!override) {
-				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "%s::%s() already exists, not importing", ZSTR_VAL(dce->name), ZSTR_VAL(fe->common.function_name));
+				php_error_docref(NULL, E_NOTICE, "%s::%s() already exists, not importing", ZSTR_VAL(dce->name), ZSTR_VAL(fe->common.function_name));
 				zend_string_release(fn);
 				continue;
 			}
 
 			scope = php_runkit_locate_scope(dce, dfe, fn);
 
-			if (php_runkit_check_call_stack(&dfe->op_array TSRMLS_CC) == FAILURE) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot override active method %s::%s(). Skipping.", ZSTR_VAL(dce->name), ZSTR_VAL(fe->common.function_name));
+			if (php_runkit_check_call_stack(&dfe->op_array) == FAILURE) {
+				php_error_docref(NULL, E_WARNING, "Cannot override active method %s::%s(). Skipping.", ZSTR_VAL(dce->name), ZSTR_VAL(fe->common.function_name));
 				zend_string_release(fn);
 				continue;
 			}
@@ -150,9 +150,9 @@ static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_ent
 			*clear_cache = 1;
 
 			php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), scope, dce, fn, dfe);
-			php_runkit_remove_function_from_reflection_objects(dfe TSRMLS_CC);
+			php_runkit_remove_function_from_reflection_objects(dfe);
 			if (zend_hash_del(&dce->function_table, fn) == FAILURE) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error removing old method in destination class %s::%s", ZSTR_VAL(dce->name), ZSTR_VAL(fe->common.function_name));
+				php_error_docref(NULL, E_WARNING, "Error removing old method in destination class %s::%s", ZSTR_VAL(dce->name), ZSTR_VAL(fe->common.function_name));
 				zend_string_release(fn);
 				continue;
 			}
@@ -160,7 +160,7 @@ static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_ent
 
 		fe->common.scope = dce;
 		if (zend_hash_add_ptr(&dce->function_table, fn, fe) == NULL) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Failure importing %s::%s()", ZSTR_VAL(ce->name), ZSTR_VAL(fe->common.function_name));
+			php_error_docref(NULL, E_WARNING, "Failure importing %s::%s()", ZSTR_VAL(ce->name), ZSTR_VAL(fe->common.function_name));
 			zend_string_release(fn);
 			continue;
 		} else {
@@ -168,11 +168,11 @@ static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_ent
 		}
 
 		if ((fe = zend_hash_find_ptr(&dce->function_table, fn)) == NULL) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot get newly created method %s::%s()", ZSTR_VAL(ce->name), ZSTR_VAL(fn));
+			php_error_docref(NULL, E_WARNING, "Cannot get newly created method %s::%s()", ZSTR_VAL(ce->name), ZSTR_VAL(fn));
 			zend_string_release(fn);
 			continue;
 		}
-		PHP_RUNKIT_ADD_MAGIC_METHOD(dce, fn, fe, dfe TSRMLS_CC);
+		PHP_RUNKIT_ADD_MAGIC_METHOD(dce, fn, fe, dfe);
 		php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)),
 		                               dce, dce, fe, fn, dfe);
 
@@ -185,7 +185,7 @@ static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_ent
 
 /* {{{ php_runkit_import_class_consts
  */
-static int php_runkit_import_class_consts(zend_class_entry *dce, zend_class_entry *ce, int override TSRMLS_DC)
+static int php_runkit_import_class_consts(zend_class_entry *dce, zend_class_entry *ce, int override)
 {
 	zend_string *key;
 #if PHP_VERSION_ID >= 70100
@@ -205,14 +205,14 @@ static int php_runkit_import_class_consts(zend_class_entry *dce, zend_class_entr
 #endif
 
 		if (key == NULL) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Constant has invalid key name");
+			php_error_docref(NULL, E_WARNING, "Constant has invalid key name");
 			continue;
 		}
 		if (zend_hash_exists(&dce->constants_table, key)) {
 			if (override) {
 				action = HASH_UPDATE;
 			} else {
-				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "%s::%s already exists, not importing", ZSTR_VAL(dce->name), ZSTR_VAL(key));
+				php_error_docref(NULL, E_NOTICE, "%s::%s already exists, not importing", ZSTR_VAL(dce->name), ZSTR_VAL(key));
 				continue;
 			}
 		}
@@ -220,7 +220,7 @@ static int php_runkit_import_class_consts(zend_class_entry *dce, zend_class_entr
 		access_type = Z_ACCESS_FLAGS(*c_zval);
 #endif
 
-		php_runkit_zval_resolve_class_constant(c_zval, dce TSRMLS_CC);
+		php_runkit_zval_resolve_class_constant(c_zval, dce);
 		Z_TRY_ADDREF_P(c_zval);
 
 		// TODO: Does this need to create copies of the zend_class_constant?
@@ -230,7 +230,7 @@ static int php_runkit_import_class_consts(zend_class_entry *dce, zend_class_entr
 		if (zend_hash_add_or_update(&dce->constants_table, key, c_zval, action) == NULL) {
 #endif
 			Z_TRY_DELREF_P(c_zval);
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to import %s::%s", ZSTR_VAL(dce->name), ZSTR_VAL(key));
+			php_error_docref(NULL, E_WARNING, "Unable to import %s::%s", ZSTR_VAL(dce->name), ZSTR_VAL(key));
 		}
 
 		php_runkit_update_children_consts_foreach(EG(class_table), dce, c_zval, key RUNKIT_CONST_FLAGS_CC(access_type));
@@ -241,7 +241,7 @@ static int php_runkit_import_class_consts(zend_class_entry *dce, zend_class_entr
 
 /* {{{ php_runkit_import_class_static_props
  */
-static int php_runkit_import_class_static_props(zend_class_entry *dce, zend_class_entry *ce, const int override, int remove_from_objects TSRMLS_DC)
+static int php_runkit_import_class_static_props(zend_class_entry *dce, zend_class_entry *ce, const int override, int remove_from_objects)
 {
 	zend_string *key;
 	zend_property_info *property_info_ptr;
@@ -251,7 +251,7 @@ static int php_runkit_import_class_static_props(zend_class_entry *dce, zend_clas
 		zval *p;
 		zend_property_info *ex_property_info_ptr;
 		if (key == NULL) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Property has invalid key name");
+			php_error_docref(NULL, E_WARNING, "Property has invalid key name");
 			continue;
 		}
 		if (!(property_info_ptr->flags & ZEND_ACC_STATIC)) {
@@ -260,29 +260,29 @@ static int php_runkit_import_class_static_props(zend_class_entry *dce, zend_clas
 		p = &CE_STATIC_MEMBERS(ce)[property_info_ptr->offset];
 		if ((ex_property_info_ptr = zend_hash_find_ptr(&dce->properties_info, key)) != NULL) {
 			if (override) {
-				if (php_runkit_def_prop_remove_int(dce, key, NULL, 0, 0, NULL TSRMLS_CC) != SUCCESS) {
-					php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to import %s::$%s (cannot remove old member)", ZSTR_VAL(dce->name), ZSTR_VAL(key));
+				if (php_runkit_def_prop_remove_int(dce, key, NULL, 0, 0, NULL) != SUCCESS) {
+					php_error_docref(NULL, E_WARNING, "Unable to import %s::$%s (cannot remove old member)", ZSTR_VAL(dce->name), ZSTR_VAL(key));
 					continue;
 				}
-				php_runkit_zval_resolve_class_constant(p, dce TSRMLS_CC);
+				php_runkit_zval_resolve_class_constant(p, dce);
 				if (php_runkit_def_prop_add_int(dce, key, p, property_info_ptr->flags,
 												property_info_ptr->doc_comment, dce,
-												override, remove_from_objects TSRMLS_CC) != SUCCESS) {
-					php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to import %s::$%s (cannot add new member)", ZSTR_VAL(dce->name), ZSTR_VAL(key));
+												override, remove_from_objects) != SUCCESS) {
+					php_error_docref(NULL, E_WARNING, "Unable to import %s::$%s (cannot add new member)", ZSTR_VAL(dce->name), ZSTR_VAL(key));
 					continue;
 				}
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Attempting to override definition of %s::$%s , runkit doesn't support that.", ZSTR_VAL(dce->name), ZSTR_VAL(key));
+				php_error_docref(NULL, E_WARNING, "Attempting to override definition of %s::$%s , runkit doesn't support that.", ZSTR_VAL(dce->name), ZSTR_VAL(key));
 				continue;
 			} else {
-				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "%s::$%s already exists, not importing", ZSTR_VAL(dce->name), ZSTR_VAL(key));
+				php_error_docref(NULL, E_NOTICE, "%s::$%s already exists, not importing", ZSTR_VAL(dce->name), ZSTR_VAL(key));
 				continue;
 			}
 		} else {
 			if (php_runkit_def_prop_add_int(dce, key, p, property_info_ptr->flags,
 											property_info_ptr->doc_comment,
 											dce,
-											override, remove_from_objects TSRMLS_CC) != SUCCESS) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to import %s::$%s (cannot add new member)", ZSTR_VAL(dce->name), ZSTR_VAL(key));
+											override, remove_from_objects) != SUCCESS) {
+				php_error_docref(NULL, E_WARNING, "Unable to import %s::$%s (cannot add new member)", ZSTR_VAL(dce->name), ZSTR_VAL(key));
 				continue;
 			}
 		}
@@ -293,7 +293,7 @@ static int php_runkit_import_class_static_props(zend_class_entry *dce, zend_clas
 
 /* {{{ php_runkit_import_class_props
  */
-static int php_runkit_import_class_props(zend_class_entry *dce, zend_class_entry *ce, int override, int remove_from_objects TSRMLS_DC)
+static int php_runkit_import_class_props(zend_class_entry *dce, zend_class_entry *ce, int override, int remove_from_objects)
 {
 	zend_string *key;
 
@@ -313,7 +313,7 @@ static int php_runkit_import_class_props(zend_class_entry *dce, zend_class_entry
 		}
 		if (zend_hash_exists(&dce->properties_info, key)) {
 			if (!override) {
-				php_error_docref(NULL TSRMLS_CC, E_NOTICE, "%s%s%s already exists, not importing",
+				php_error_docref(NULL, E_NOTICE, "%s%s%s already exists, not importing",
 								 ZSTR_VAL(dce->name), (property_info_ptr->flags & ZEND_ACC_STATIC) ? "::$" : "->", ZSTR_VAL(key));
 				continue;
 			}
@@ -323,16 +323,16 @@ static int php_runkit_import_class_props(zend_class_entry *dce, zend_class_entry
 		// TODO: Figure out if this is the correct replacement - copied from add_class_vars
 		// if ((p_src = zend_hash_find(&ce->default_properties, property_info_ptr->name)) == NULL)
 		if (Z_TYPE_P(p) == IS_UNDEF) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING,
+			php_error_docref(NULL, E_WARNING,
 							 "Cannot import broken default property %s->%s", ZSTR_VAL(ce->name), ZSTR_VAL(key));
 			continue;
 		}
 
 		// TODO: Fix constant check
-		php_runkit_zval_resolve_class_constant(p, dce TSRMLS_CC);
+		php_runkit_zval_resolve_class_constant(p, dce);
 		php_runkit_def_prop_add_int(dce, key, p,
 									property_info_ptr->flags, property_info_ptr->doc_comment,
-									dce, override, remove_from_objects TSRMLS_CC);
+									dce, override, remove_from_objects);
 	} ZEND_HASH_FOREACH_END();
 
 	return SUCCESS;
@@ -355,19 +355,19 @@ static int php_runkit_import_classes(HashTable *class_table, const long flags
 		zend_class_entry *dce;
 
 		if (Z_TYPE_P(ce_zv) != IS_PTR) {
-			php_error_docref(NULL TSRMLS_CC, E_ERROR, "Non-class in class table!");
+			php_error_docref(NULL, E_ERROR, "Non-class in class table!");
 			return FAILURE;
 		}
 		ce = Z_PTR_P(ce_zv);
 		if (ce == NULL) {
-			php_error_docref(NULL TSRMLS_CC, E_ERROR, "Null class in class table!");
+			php_error_docref(NULL, E_ERROR, "Null class in class table!");
 		}
 
 		if (ce->type != ZEND_USER_CLASS) {
 			if (ce->type == ZEND_INTERNAL_CLASS) {
-				php_error_docref(NULL TSRMLS_CC, E_ERROR, "Cannot import internal class!");
+				php_error_docref(NULL, E_ERROR, "Cannot import internal class!");
 			} else {
-				php_error_docref(NULL TSRMLS_CC, E_ERROR, "Corrupt class table?");
+				php_error_docref(NULL, E_ERROR, "Corrupt class table?");
 			}
 			return FAILURE;
 		}
@@ -385,18 +385,18 @@ static int php_runkit_import_classes(HashTable *class_table, const long flags
 			classname_lower = zend_string_tolower(classname);
 
 			if (!zend_hash_exists(EG(class_table), classname_lower)) {
-				php_runkit_class_copy(ce, ce->name TSRMLS_CC);
+				php_runkit_class_copy(ce, ce->name);
 			}
 			zend_string_release(classname_lower);
 
-			if ((dce = php_runkit_fetch_class(ce->name TSRMLS_CC)) == NULL) {
+			if ((dce = php_runkit_fetch_class(ce->name)) == NULL) {
 				/* Oddly non-existant target class or error retreiving it... Or it's an internal class... */
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot redeclare class %s", ZSTR_VAL(ce->name));
+				php_error_docref(NULL, E_WARNING, "Cannot redeclare class %s", ZSTR_VAL(ce->name));
 				continue;
 			}
 
 			if (flags & PHP_RUNKIT_IMPORT_CLASS_CONSTS) {
-				php_runkit_import_class_consts(dce, ce, (flags & PHP_RUNKIT_IMPORT_OVERRIDE) TSRMLS_CC);
+				php_runkit_import_class_consts(dce, ce, (flags & PHP_RUNKIT_IMPORT_OVERRIDE));
 			}
 			if (flags & PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS) {
 				php_runkit_import_class_static_props(dce, ce, (flags & PHP_RUNKIT_IMPORT_OVERRIDE) != 0,
@@ -434,7 +434,7 @@ static int php_runkit_import_classes(HashTable *class_table, const long flags
  *
  * It would be cleaner to temporarily set zend_compile_file back to compile_file, but that wouldn't be
  * particularly thread-safe so.... */
-static zend_op_array *php_runkit_compile_filename(int type, zval *filename TSRMLS_DC)
+static zend_op_array *php_runkit_compile_filename(int type, zval *filename)
 {
 	zend_file_handle file_handle;
 	zval tmp;
@@ -454,7 +454,7 @@ static zend_op_array *php_runkit_compile_filename(int type, zval *filename TSRML
 	file_handle.handle.fp = NULL;
 
 	/* Use builtin compiler only -- bypass accelerators and whatnot */
-	retval = compile_file(&file_handle, type TSRMLS_CC);
+	retval = compile_file(&file_handle, type);
 	if (retval && file_handle.handle.stream.handle) {
 		// TODO: Duplicate instead?
 		if (!file_handle.opened_path) {
@@ -467,7 +467,7 @@ static zend_op_array *php_runkit_compile_filename(int type, zval *filename TSRML
 			zend_string_release(opened_path);
 		}
 	}
-	zend_destroy_file_handle(&file_handle TSRMLS_CC);
+	zend_destroy_file_handle(&file_handle);
 
 	if (filename==&tmp) {
 		zval_dtor(&tmp);
@@ -507,21 +507,21 @@ PHP_FUNCTION(runkit_import)
 	zend_long flags = PHP_RUNKIT_IMPORT_CLASS_METHODS;
 	zend_bool clear_cache = 0;
 
-	zend_op_array *(*local_compile_filename)(int type, zval *filename TSRMLS_DC) = compile_filename;
+	zend_op_array *(*local_compile_filename)(int type, zval *filename) = compile_filename;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z|l", &filename, &flags) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z|l", &filename, &flags) == FAILURE) {
 		RETURN_FALSE;
 	}
 	if (flags & PHP_RUNKIT_IMPORT_OVERRIDE) {
 		if (flags & (PHP_RUNKIT_IMPORT_CLASS_PROPS | PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS)) {
 			/* TODO: Investigate if static props are possible. https://github.com/runkit7/runkit7/issues/73 */
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Using PHP_RUNKIT_IMPORT_OVERRIDE in combination with PHP_RUNKIT_IMPORT_CLASS_PROPS/PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS is not supported.");
+			php_error_docref(NULL, E_WARNING, "Using PHP_RUNKIT_IMPORT_OVERRIDE in combination with PHP_RUNKIT_IMPORT_CLASS_PROPS/PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS is not supported.");
 			RETURN_FALSE;
 		}
 	}
 	if (flags & (PHP_RUNKIT_IMPORT_CLASS_PROPS | PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS)) {
 		/* TODO: Investigate if static props are possible. https://github.com/runkit7/runkit7/issues/73 */
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "PHP_RUNKIT_IMPORT_CLASS_PROPS/PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS are not supported yet, runkit_props.c has not been fully ported.");
+		php_error_docref(NULL, E_WARNING, "PHP_RUNKIT_IMPORT_CLASS_PROPS/PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS are not supported yet, runkit_props.c has not been fully ported.");
 		RETURN_FALSE;
 	}
 	convert_to_string(filename);
@@ -551,7 +551,7 @@ PHP_FUNCTION(runkit_import)
 	php_runkit_old_compiler_options = CG(compiler_options);
 	CG(compiler_options) |= ZEND_COMPILE_DELAYED_BINDING;
 
-	new_op_array = local_compile_filename(ZEND_INCLUDE, filename TSRMLS_CC);
+	new_op_array = local_compile_filename(ZEND_INCLUDE, filename);
 
 	/* zend_error_cb = php_runkit_old_error_cb; */
 	CG(class_table) = current_class_table;
@@ -567,7 +567,7 @@ PHP_FUNCTION(runkit_import)
 		zend_hash_destroy(tmp_function_table);
 		efree(tmp_function_table);
 		if (!EG(exception)) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Import Failure");
+			php_error_docref(NULL, E_WARNING, "Import Failure");
 		}
 		RETURN_FALSE;
 	}
@@ -603,15 +603,15 @@ PHP_FUNCTION(runkit_import)
 	}
 
 	/* We never really needed the main loop opcodes to begin with */
-	destroy_op_array(new_op_array TSRMLS_CC);
+	destroy_op_array(new_op_array);
 	efree(new_op_array);
 
 	if (flags & PHP_RUNKIT_IMPORT_FUNCTIONS) {
-		php_runkit_import_functions(tmp_function_table, flags, &clear_cache TSRMLS_CC);
+		php_runkit_import_functions(tmp_function_table, flags, &clear_cache);
 	}
 
 	if (flags & PHP_RUNKIT_IMPORT_CLASSES) {
-		php_runkit_import_classes(tmp_class_table, flags, &clear_cache TSRMLS_CC);
+		php_runkit_import_classes(tmp_class_table, flags, &clear_cache);
 	}
 
 	zend_hash_destroy(tmp_class_table);

--- a/runkit_import.c
+++ b/runkit_import.c
@@ -147,7 +147,7 @@ static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_ent
 
 			*clear_cache = 1;
 
-			php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), scope, dce, fn, dfe);
+			php_runkit_clean_children_methods_foreach(EG(class_table), scope, dce, fn, dfe);
 			php_runkit_remove_function_from_reflection_objects(dfe);
 			if (zend_hash_del(&dce->function_table, fn) == FAILURE) {
 				php_error_docref(NULL, E_WARNING, "Error removing old method in destination class %s::%s", ZSTR_VAL(dce->name), ZSTR_VAL(fe->common.function_name));
@@ -171,7 +171,7 @@ static int php_runkit_import_class_methods(zend_class_entry *dce, zend_class_ent
 			continue;
 		}
 		PHP_RUNKIT_ADD_MAGIC_METHOD(dce, fn, fe, dfe);
-		php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)),
+		php_runkit_update_children_methods_foreach(EG(class_table),
 		                               dce, dce, fe, fn, dfe);
 
 		zend_string_release(fn);
@@ -478,8 +478,6 @@ static uint32_t php_runkit_old_compiler_options;
 /* Disabled because php deprecation notices were causing EG(class_table) to be restored too early */
 /*
 void php_runkit_error_cb(int type, const char *error_filename, const uint error_lineno, const char *format, va_list args) {
-	TSRMLS_FETCH();
-
 	zend_error_cb = php_runkit_old_error_cb;
 	CG(class_table) = current_class_table;
 	EG(class_table) = current_eg_class_table;

--- a/runkit_methods.c
+++ b/runkit_methods.c
@@ -27,7 +27,7 @@
 
 /* {{{ _php_runkit_get_method_prototype
 	Locates the prototype method with name func_lower in the inheritance chain of ce. */
-static inline zend_function* _php_runkit_get_method_prototype(zend_class_entry *ce, zend_string* func_lower TSRMLS_DC) {
+static inline zend_function* _php_runkit_get_method_prototype(zend_class_entry *ce, zend_string* func_lower) {
 	zend_class_entry *pce = ce;
 	zend_function *proto = NULL;
 
@@ -60,12 +60,12 @@ zend_class_entry *php_runkit_fetch_class(zend_string *classname)
 	}
 
 	if (ce->type != ZEND_USER_CLASS) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "class %s is not a user-defined class", ZSTR_VAL(classname));
+		php_error_docref(NULL, E_WARNING, "class %s is not a user-defined class", ZSTR_VAL(classname));
 		return NULL;
 	}
 
 	if (ce->ce_flags & ZEND_ACC_INTERFACE) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "class %s is an interface", ZSTR_VAL(classname));
+		php_error_docref(NULL, E_WARNING, "class %s is an interface", ZSTR_VAL(classname));
 		return NULL;
 	}
 	// TODO: What about traits? (ZEND_ACC_TRAIT)
@@ -76,14 +76,14 @@ zend_class_entry *php_runkit_fetch_class(zend_string *classname)
 
 /* {{{ php_runkit_fetch_interface
  */
-int php_runkit_fetch_interface(zend_string* classname, zend_class_entry **pce TSRMLS_DC)
+int php_runkit_fetch_interface(zend_string* classname, zend_class_entry **pce)
 {
 	if ((*pce = php_runkit_fetch_class_int(classname)) == NULL) {
 		return FAILURE;
 	}
 
 	if (!((*pce)->ce_flags & ZEND_ACC_INTERFACE)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "class %s is not an interface", ZSTR_VAL(classname));
+		php_error_docref(NULL, E_WARNING, "class %s is not an interface", ZSTR_VAL(classname));
 		return FAILURE;
 	}
 
@@ -93,7 +93,7 @@ int php_runkit_fetch_interface(zend_string* classname, zend_class_entry **pce TS
 
 /* {{{ php_runkit_fetch_class_method
  */
-static int php_runkit_fetch_class_method(zend_string* classname, zend_string* fname, zend_class_entry **pce, zend_function **pfe TSRMLS_DC)
+static int php_runkit_fetch_class_method(zend_string* classname, zend_string* fname, zend_class_entry **pce, zend_function **pfe)
 {
 	zend_class_entry *ce;
 	zend_function *fe;
@@ -104,7 +104,7 @@ static int php_runkit_fetch_class_method(zend_string* classname, zend_string* fn
 	}
 
 	if (ce->type != ZEND_USER_CLASS) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "class %s is not a user-defined class", ZSTR_VAL(classname));
+		php_error_docref(NULL, E_WARNING, "class %s is not a user-defined class", ZSTR_VAL(classname));
 		return FAILURE;
 	}
 
@@ -115,14 +115,14 @@ static int php_runkit_fetch_class_method(zend_string* classname, zend_string* fn
 	fname_lower = zend_string_tolower(fname);
 
 	if ((fe = zend_hash_find_ptr(&ce->function_table, fname_lower)) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s::%s() not found", ZSTR_VAL(classname), ZSTR_VAL(fname));
+		php_error_docref(NULL, E_WARNING, "%s::%s() not found", ZSTR_VAL(classname), ZSTR_VAL(fname));
 		zend_string_release(fname_lower);
 		return FAILURE;
 	}
 
 	zend_string_release(fname_lower);
 	if (fe->type != ZEND_USER_FUNCTION) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s::%s() is not a user function", ZSTR_VAL(classname), ZSTR_VAL(fname));
+		php_error_docref(NULL, E_WARNING, "%s::%s() is not a user function", ZSTR_VAL(classname), ZSTR_VAL(fname));
 		return FAILURE;
 	}
 
@@ -145,7 +145,7 @@ void php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_ARG(HashTable *
 
 
 /* {{{ php_runkit_inherit_magic */
-inline static void php_runkit_inherit_magic(zend_class_entry *ce, const zend_function *fe, const zend_function *orig_fe TSRMLS_DC) {
+inline static void php_runkit_inherit_magic(zend_class_entry *ce, const zend_function *fe, const zend_function *orig_fe) {
 	if ((ce)->__get == (orig_fe) && (ce)->parent->__get == (fe)) {
 		(ce)->__get        = (ce)->parent->__get;
 		ensure_all_objects_of_class_have_magic_methods(ce);
@@ -172,10 +172,10 @@ inline static void php_runkit_inherit_magic(zend_class_entry *ce, const zend_fun
 		(ce)->constructor  = (ce)->parent->constructor;
 	} else if ((ce)->__debugInfo  == (orig_fe) && (ce)->parent->__debugInfo == (fe)) {
 		(ce)->__debugInfo  = (ce)->parent->__debugInfo;
-	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1 TSRMLS_CC) &&
+	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1) &&
 		   (ce)->serialize_func == (orig_fe) && (ce)->parent->serialize_func == (fe)) {
 		(ce)->serialize_func = (ce)->parent->serialize_func;
-	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1 TSRMLS_CC) &&
+	} else if (instanceof_function_ex(ce, zend_ce_serializable, 1) &&
 		   (ce)->unserialize_func == (orig_fe) && (ce)->parent->unserialize_func == (fe)) {
 		(ce)->unserialize_func = (ce)->parent->unserialize_func;
 	}
@@ -200,7 +200,7 @@ void php_runkit_update_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *c
 		scope = php_runkit_locate_scope(ce, cfe, fname_lower);
 		if (scope != ancestor_class) {
 			/* This method was defined below our current level, leave it be */
-			cfe->common.prototype = _php_runkit_get_method_prototype(scope->parent, fname_lower TSRMLS_CC);
+			cfe->common.prototype = _php_runkit_get_method_prototype(scope->parent, fname_lower);
 			php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)),
 						ancestor_class, ce, fe, fname_lower, orig_fe);
 			return;
@@ -208,20 +208,20 @@ void php_runkit_update_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *c
 	}
 
 	if (cfe) {
-		php_runkit_remove_function_from_reflection_objects(cfe TSRMLS_CC);
+		php_runkit_remove_function_from_reflection_objects(cfe);
 		if (zend_hash_del(&ce->function_table, fname_lower) == FAILURE) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error updating child class");
+			php_error_docref(NULL, E_WARNING, "Error updating child class");
 			return;
 		}
 	}
 
 	// TODO: memcpy?
 	if (zend_hash_add_ptr(&ce->function_table, fname_lower, fe) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error updating child class");
+		php_error_docref(NULL, E_WARNING, "Error updating child class");
 		return;
 	}
 	PHP_RUNKIT_FUNCTION_ADD_REF(fe);
-	php_runkit_inherit_magic(ce, fe, orig_fe TSRMLS_CC);
+	php_runkit_inherit_magic(ce, fe, orig_fe);
 
 	/* Process children of this child */
 	php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)),
@@ -268,11 +268,11 @@ void php_runkit_clean_children_methods(RUNKIT_53_TSRMLS_ARG(zend_class_entry *ce
 	/* Process children of this child */
 	php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ancestor_class, ce, fname_lower, orig_cfe);
 
-	php_runkit_remove_function_from_reflection_objects(cfe TSRMLS_CC);
+	php_runkit_remove_function_from_reflection_objects(cfe);
 
 	zend_hash_del(&ce->function_table, fname_lower);
 
-	PHP_RUNKIT_DEL_MAGIC_METHOD(ce, orig_cfe TSRMLS_CC);
+	PHP_RUNKIT_DEL_MAGIC_METHOD(ce, orig_cfe);
 }
 /* }}} */
 
@@ -295,20 +295,20 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 
 	if (argc < 2 || zend_parse_parameters_ex(ZEND_PARSE_PARAMS_QUIET, 2, "SS", &classname, &methodname) == FAILURE ||
 			!ZSTR_LEN(classname) || !ZSTR_LEN(methodname)) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Class name and method name should not be empty");
+		php_error_docref(NULL, E_ERROR, "Class name and method name should not be empty");
 		RETURN_FALSE;
 	}
 
 	if (argc < 3) {
-		php_error_docref(NULL TSRMLS_CC, E_ERROR, "Method body should be provided");
+		php_error_docref(NULL, E_ERROR, "Method body should be provided");
 		RETURN_FALSE;
 	}
 
-	if (!php_runkit_parse_args_to_zvals(argc, &args TSRMLS_CC)) {
+	if (!php_runkit_parse_args_to_zvals(argc, &args)) {
 		RETURN_FALSE;
 	}
 
-	if (!php_runkit_parse_function_arg(argc, args, 2, &source_fe, &arguments, &phpcode, &opt_arg_pos, "Method" TSRMLS_CC)) {
+	if (!php_runkit_parse_function_arg(argc, args, 2, &source_fe, &arguments, &phpcode, &opt_arg_pos, "Method")) {
 		efree(args);
 		RETURN_FALSE;
 	}
@@ -318,10 +318,10 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 			convert_to_long_ex(&(args[opt_arg_pos]));
 			flags = Z_LVAL(args[opt_arg_pos]);
 			if (flags & PHP_RUNKIT_ACC_RETURN_REFERENCE && source_fe) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "RUNKIT_ACC_RETURN_REFERENCE flag is not applicable for closures, use & in closure definition instead");
+				php_error_docref(NULL, E_WARNING, "RUNKIT_ACC_RETURN_REFERENCE flag is not applicable for closures, use & in closure definition instead");
 			}
 		} else {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Flags should be a long integer or NULL");
+			php_error_docref(NULL, E_WARNING, "Flags should be a long integer or NULL");
 		}
 	}
 
@@ -339,22 +339,22 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 
 	if (source_fe && return_type.return_type) {
 		// TODO: Check what needs to be needs to be changed in opcode array if return_type is changed
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Overriding return_type is not currently supported for closures, use return type in closure definition instead (or pass in code as string)");
+		php_error_docref(NULL, E_WARNING, "Overriding return_type is not currently supported for closures, use return type in closure definition instead (or pass in code as string)");
 		RETURN_FALSE;
 	}
 
 	methodname_lower = zend_string_tolower(methodname);
 
 	if (add_or_update == HASH_UPDATE) {
-		if (php_runkit_fetch_class_method(classname, methodname_lower, &ce, &fe TSRMLS_CC) == FAILURE) {
+		if (php_runkit_fetch_class_method(classname, methodname_lower, &ce, &fe) == FAILURE) {
 			zend_string_release(methodname_lower);
 			RETURN_FALSE;
 		}
 		ancestor_class = php_runkit_locate_scope(ce, fe, methodname_lower);
 		orig_fe = fe;
 
-		if (php_runkit_check_call_stack(&fe->op_array TSRMLS_CC) == FAILURE) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot redefine a method while that method is active.");
+		if (php_runkit_check_call_stack(&fe->op_array) == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "Cannot redefine a method while that method is active.");
 			zend_string_release(methodname_lower);
 			RETURN_FALSE;
 		}
@@ -366,11 +366,11 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 		ancestor_class = ce;
 		if ((fe = zend_hash_find_ptr(&ce->function_table, methodname_lower)) != NULL) {
 			if (php_runkit_locate_scope(ce, fe, methodname_lower) == ce) {
-				php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s::%s() already exists", ZSTR_VAL(classname), ZSTR_VAL(methodname));
+				php_error_docref(NULL, E_WARNING, "%s::%s() already exists", ZSTR_VAL(classname), ZSTR_VAL(methodname));
 				zend_string_release(methodname_lower);
 				RETURN_FALSE;
 			} else {
-				php_runkit_remove_function_from_reflection_objects(fe TSRMLS_CC);
+				php_runkit_remove_function_from_reflection_objects(fe);
 				zend_hash_del(&ce->function_table, methodname_lower);
 			}
 		}
@@ -387,7 +387,7 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 		remove_temp = 1;
 	}
 
-	func = php_runkit_function_clone(source_fe, methodname, (orig_fe ? orig_fe->type : ZEND_USER_FUNCTION) TSRMLS_CC);
+	func = php_runkit_function_clone(source_fe, methodname, (orig_fe ? orig_fe->type : ZEND_USER_FUNCTION));
 
 	if (flags & ZEND_ACC_PRIVATE) {
 		func->common.fn_flags &= ~ZEND_ACC_PPP_MASK;
@@ -416,11 +416,11 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 
 	if(orig_fe) {
-		php_runkit_remove_function_from_reflection_objects(orig_fe TSRMLS_CC);
+		php_runkit_remove_function_from_reflection_objects(orig_fe);
 	}
 
 	if (runkit_zend_hash_add_or_update_ptr(&ce->function_table, methodname_lower, func, add_or_update) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to add method to class");
+		php_error_docref(NULL, E_WARNING, "Unable to add method to class");
 		php_runkit_function_dtor(func);
 		zend_string_release(methodname_lower);
 		if (remove_temp) {
@@ -435,15 +435,15 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 	}
 
 	if ((fe = zend_hash_find_ptr(&ce->function_table, methodname_lower)) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate newly added method");
+		php_error_docref(NULL, E_WARNING, "Unable to locate newly added method");
 		zend_string_release(methodname_lower);
 		RETURN_FALSE;
 	}
 
 	fe->common.scope = ce;
-	fe->common.prototype = _php_runkit_get_method_prototype(ce->parent, methodname_lower TSRMLS_CC);
+	fe->common.prototype = _php_runkit_get_method_prototype(ce->parent, methodname_lower);
 
-	PHP_RUNKIT_ADD_MAGIC_METHOD(ce, methodname_lower, fe, orig_fe TSRMLS_CC);
+	PHP_RUNKIT_ADD_MAGIC_METHOD(ce, methodname_lower, fe, orig_fe);
 	php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ancestor_class, ce, fe, methodname_lower, orig_fe);
 
 	zend_string_release(methodname_lower);
@@ -454,14 +454,14 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 
 /* {{{ php_runkit_method_copy
  */
-static int php_runkit_method_copy(zend_string *dclass, zend_string* dfunc, zend_string* sclass, zend_string* sfunc TSRMLS_DC)
+static int php_runkit_method_copy(zend_string *dclass, zend_string* dfunc, zend_string* sclass, zend_string* sfunc)
 {
 	zend_class_entry *dce, *sce;
 	zend_function *sfe, *dfe;
 	zend_string* dfunc_lower;
 	zend_function *fe;
 
-	if (php_runkit_fetch_class_method(sclass, sfunc, &sce, &sfe TSRMLS_CC) == FAILURE) {
+	if (php_runkit_fetch_class_method(sclass, sfunc, &sce, &sfe) == FAILURE) {
 		return FAILURE;
 	}
 
@@ -473,31 +473,31 @@ static int php_runkit_method_copy(zend_string *dclass, zend_string* dfunc, zend_
 
 	if ((fe = zend_hash_find_ptr(&dce->function_table, dfunc_lower)) != NULL) {
 		if (php_runkit_locate_scope(dce, fe, dfunc_lower) == dce) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Destination method %s::%s() already exists", ZSTR_VAL(dclass), ZSTR_VAL(dfunc));
+			php_error_docref(NULL, E_WARNING, "Destination method %s::%s() already exists", ZSTR_VAL(dclass), ZSTR_VAL(dfunc));
 			zend_string_release(dfunc_lower);
 			return FAILURE;
 		} else {
-			php_runkit_remove_function_from_reflection_objects(fe TSRMLS_CC);
+			php_runkit_remove_function_from_reflection_objects(fe);
 			zend_hash_del(&dce->function_table, dfunc_lower);
 			php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 		}
 	}
 	/* Postcondition: Method does not already exist in dce's function table (Would return FAILURE if it did) */
 
-	dfe = php_runkit_function_clone(sfe, dfunc, ZEND_USER_FUNCTION TSRMLS_CC);
+	dfe = php_runkit_function_clone(sfe, dfunc, ZEND_USER_FUNCTION);
 
 	// TODO: Check if this is a memory leak.
 	if (zend_hash_add_ptr(&dce->function_table, dfunc_lower, dfe) == NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Error adding method to class %s::%s()", ZSTR_VAL(dclass), ZSTR_VAL(dfunc));
+		php_error_docref(NULL, E_WARNING, "Error adding method to class %s::%s()", ZSTR_VAL(dclass), ZSTR_VAL(dfunc));
 		zend_string_release(dfunc_lower);
 		efree(dfe);
 		return FAILURE;
 	}
 
 	dfe->common.scope = dce;
-	dfe->common.prototype = _php_runkit_get_method_prototype(dce->parent, dfunc_lower TSRMLS_CC);
+	dfe->common.prototype = _php_runkit_get_method_prototype(dce->parent, dfunc_lower);
 
-	PHP_RUNKIT_ADD_MAGIC_METHOD(dce, dfunc_lower, dfe, NULL TSRMLS_CC);
+	PHP_RUNKIT_ADD_MAGIC_METHOD(dce, dfunc_lower, dfe, NULL);
 
 	php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), dce, dce, dfe, dfunc_lower, NULL);
 
@@ -538,18 +538,18 @@ PHP_FUNCTION(runkit_method_remove)
 	zend_string* classname;
 	zend_string* methodname_lower;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS", &classname, &methodname) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Can't parse parameters");
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &classname, &methodname) == FAILURE) {
+		php_error_docref(NULL, E_WARNING, "Can't parse parameters");
 		RETURN_FALSE;
 	}
 
 	if (!ZSTR_LEN(classname) || !ZSTR_LEN(methodname)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Empty parameter given");
+		php_error_docref(NULL, E_WARNING, "Empty parameter given");
 		RETURN_FALSE;
 	}
 
-	if (php_runkit_fetch_class_method(classname, methodname, &ce, &fe TSRMLS_CC) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown method %s::%s()", ZSTR_VAL(classname), ZSTR_VAL(methodname));
+	if (php_runkit_fetch_class_method(classname, methodname, &ce, &fe) == FAILURE) {
+		php_error_docref(NULL, E_WARNING, "Unknown method %s::%s()", ZSTR_VAL(classname), ZSTR_VAL(methodname));
 		RETURN_FALSE;
 	}
 
@@ -561,16 +561,16 @@ PHP_FUNCTION(runkit_method_remove)
 
 	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 
-	php_runkit_remove_function_from_reflection_objects(fe TSRMLS_CC);
+	php_runkit_remove_function_from_reflection_objects(fe);
 
 	if (zend_hash_del(&ce->function_table, methodname_lower) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to remove method from class");
+		php_error_docref(NULL, E_WARNING, "Unable to remove method from class");
 		zend_string_release(methodname_lower);
 		RETURN_FALSE;
 	}
 
 	zend_string_release(methodname_lower);
-	PHP_RUNKIT_DEL_MAGIC_METHOD(ce, fe TSRMLS_CC);
+	PHP_RUNKIT_DEL_MAGIC_METHOD(ce, fe);
 
 	RETURN_TRUE;
 }
@@ -589,17 +589,17 @@ PHP_FUNCTION(runkit_method_rename)
 	zend_string* methodname_lower;
 
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SSS",	&classname, &methodname, &newname) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SSS",	&classname, &methodname, &newname) == FAILURE) {
 		RETURN_FALSE;
 	}
 
 	if (!ZSTR_LEN(classname) || !ZSTR_LEN(methodname) || !ZSTR_LEN(newname)) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Empty parameter given");
+		php_error_docref(NULL, E_WARNING, "Empty parameter given");
 		RETURN_FALSE;
 	}
 
-	if (php_runkit_fetch_class_method(classname, methodname, &ce, &fe TSRMLS_CC) == FAILURE) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unknown method %s::%s()", ZSTR_VAL(classname), ZSTR_VAL(methodname));
+	if (php_runkit_fetch_class_method(classname, methodname, &ce, &fe) == FAILURE) {
+		php_error_docref(NULL, E_WARNING, "Unknown method %s::%s()", ZSTR_VAL(classname), ZSTR_VAL(methodname));
 		RETURN_FALSE;
 	}
 
@@ -608,12 +608,12 @@ PHP_FUNCTION(runkit_method_rename)
 
 	if ((old_fe = zend_hash_find_ptr(&ce->function_table, newname_lower)) != NULL) {
 		if (php_runkit_locate_scope(ce, old_fe, newname_lower) == ce) {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s::%s() already exists", ZSTR_VAL(classname), ZSTR_VAL(methodname));
+			php_error_docref(NULL, E_WARNING, "%s::%s() already exists", ZSTR_VAL(classname), ZSTR_VAL(methodname));
 			zend_string_release(methodname_lower);
 			zend_string_release(newname_lower);
 			RETURN_FALSE;
 		} else {
-			php_runkit_remove_function_from_reflection_objects(old_fe TSRMLS_CC);
+			php_runkit_remove_function_from_reflection_objects(old_fe);
 			zend_hash_del(&ce->function_table, newname_lower);
 		}
 	}
@@ -624,38 +624,38 @@ PHP_FUNCTION(runkit_method_rename)
 	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 
 	/* TODO: Figure out how to find the original function type. */
-	func = php_runkit_function_clone(fe, newname, fe->type TSRMLS_CC);
+	func = php_runkit_function_clone(fe, newname, fe->type);
 
 	if (zend_hash_add_ptr(&ce->function_table, newname_lower, func) == NULL) {
 		zend_string_release(newname_lower);
 		zend_string_release(methodname_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to add new reference to class method");
+		php_error_docref(NULL, E_WARNING, "Unable to add new reference to class method");
 		php_runkit_function_dtor(func);
 		RETURN_FALSE;
 	}
 
-	php_runkit_remove_function_from_reflection_objects(fe TSRMLS_CC);
+	php_runkit_remove_function_from_reflection_objects(fe);
 
 	if (zend_hash_del(&ce->function_table, methodname_lower) == FAILURE) {
 		zend_string_release(newname_lower);
 		zend_string_release(methodname_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to remove old method reference from class");
+		php_error_docref(NULL, E_WARNING, "Unable to remove old method reference from class");
 		RETURN_FALSE;
 	}
 
-	PHP_RUNKIT_DEL_MAGIC_METHOD(ce, fe TSRMLS_CC);
+	PHP_RUNKIT_DEL_MAGIC_METHOD(ce, fe);
 
-	if (php_runkit_fetch_class_method(classname, newname, &ce, &fe TSRMLS_CC) == FAILURE) {
+	if (php_runkit_fetch_class_method(classname, newname, &ce, &fe) == FAILURE) {
 		zend_string_release(newname_lower);
 		zend_string_release(methodname_lower);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Unable to locate newly renamed method");
+		php_error_docref(NULL, E_WARNING, "Unable to locate newly renamed method");
 		RETURN_FALSE;
 	}
 
 	fe->common.scope = ce;
-	fe->common.prototype = _php_runkit_get_method_prototype(ce->parent, newname_lower TSRMLS_CC);;
+	fe->common.prototype = _php_runkit_get_method_prototype(ce->parent, newname_lower);;
 
-	PHP_RUNKIT_ADD_MAGIC_METHOD(ce, newname_lower, fe, NULL TSRMLS_CC);
+	PHP_RUNKIT_ADD_MAGIC_METHOD(ce, newname_lower, fe, NULL);
 	php_runkit_update_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ce, ce, fe, newname_lower, NULL);
 
 	zend_string_release(newname_lower);
@@ -671,7 +671,7 @@ PHP_FUNCTION(runkit_method_copy)
 {
 	zend_string* dclass, *dfunc, *sclass, *sfunc = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SSS|S", &dclass, &dfunc, &sclass, &sfunc) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SSS|S", &dclass, &dfunc, &sclass, &sfunc) == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -679,7 +679,7 @@ PHP_FUNCTION(runkit_method_copy)
 		sfunc = dfunc;
 	}
 
-	RETURN_BOOL(php_runkit_method_copy(dclass, dfunc, sclass, sfunc TSRMLS_CC) == SUCCESS ? 1 : 0);
+	RETURN_BOOL(php_runkit_method_copy(dclass, dfunc, sclass, sfunc) == SUCCESS ? 1 : 0);
 }
 /* }}} */
 #endif /* PHP_RUNKIT_MANIPULATION */

--- a/runkit_methods.c
+++ b/runkit_methods.c
@@ -379,8 +379,7 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 	if (!source_fe) {
 		if (php_runkit_generate_lambda_method(arguments, return_type.return_type, is_strict.is_strict, phpcode, &source_fe,
 						     (flags & PHP_RUNKIT_ACC_RETURN_REFERENCE) == PHP_RUNKIT_ACC_RETURN_REFERENCE,
-							 ((flags & ZEND_ACC_STATIC) != 0)
-						     TSRMLS_CC) == FAILURE) {
+							 ((flags & ZEND_ACC_STATIC) != 0)) == FAILURE) {
 			zend_string_release(methodname_lower);
 			RETURN_FALSE;
 		}
@@ -413,7 +412,7 @@ static void php_runkit_method_add_or_update(INTERNAL_FUNCTION_PARAMETERS, int ad
 	php_runkit_modify_function_doc_comment(func, doc_comment);
 
 	// TODO: Seeing if this broke it.
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	if(orig_fe) {
 		php_runkit_remove_function_from_reflection_objects(orig_fe);
@@ -479,7 +478,7 @@ static int php_runkit_method_copy(zend_string *dclass, zend_string* dfunc, zend_
 		} else {
 			php_runkit_remove_function_from_reflection_objects(fe);
 			zend_hash_del(&dce->function_table, dfunc_lower);
-			php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+			php_runkit_clear_all_functions_runtime_cache();
 		}
 	}
 	/* Postcondition: Method does not already exist in dce's function table (Would return FAILURE if it did) */
@@ -559,7 +558,7 @@ PHP_FUNCTION(runkit_method_remove)
 
 	php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ancestor_class, ce, methodname_lower, fe);
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	php_runkit_remove_function_from_reflection_objects(fe);
 
@@ -621,7 +620,7 @@ PHP_FUNCTION(runkit_method_rename)
 	ancestor_class = php_runkit_locate_scope(ce, fe, methodname_lower);
 	php_runkit_clean_children_methods_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ancestor_class, ce, methodname_lower, fe);
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 
 	/* TODO: Figure out how to find the original function type. */
 	func = php_runkit_function_clone(fe, newname, fe->type);

--- a/runkit_props.c
+++ b/runkit_props.c
@@ -192,7 +192,7 @@ int php_runkit_def_prop_add_int(zend_class_entry *ce, zend_string* propname, zva
 			return FAILURE;
 		} else {
 			php_runkit_def_prop_remove_int(ce, propname, NULL, (zend_bool) 0, override_in_objects, (zend_property_info*) NULL);
-			php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+			php_runkit_clear_all_functions_runtime_cache();
 		}
 	}
 	prop_info_ptr = NULL;
@@ -462,7 +462,7 @@ int php_runkit_def_prop_remove_int(zend_class_entry *ce, zend_string *propname, 
 		}
 
 		// php_runkit_remove_property_from_reflection_objects(ce, propname);
-		php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+		php_runkit_clear_all_functions_runtime_cache();
 	} else {
 		if (parent_property) {
 			return SUCCESS;
@@ -521,7 +521,7 @@ static int php_runkit_def_prop_remove(zend_string *classname, zend_string *propn
 		return FAILURE;
 	}
 
-	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
+	php_runkit_clear_all_functions_runtime_cache();
 	return php_runkit_def_prop_remove_int(ce, propname, NULL, 0, remove_from_objects, NULL);
 }
 /* }}} */

--- a/runkit_props.c
+++ b/runkit_props.c
@@ -112,7 +112,7 @@ static void php_runkit_remove_overlapped_property_from_childs(zend_class_entry *
 		return;
 	}
 
-	php_runkit_remove_overlapped_property_from_childs_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ce, propname, offset, is_static, remove_from_objects, property_info_ptr);
+	php_runkit_remove_overlapped_property_from_childs_foreach(EG(class_table), ce, propname, offset, is_static, remove_from_objects, property_info_ptr);
 	// php_runkit_remove_property_from_reflection_objects(ce, propname);
 
 	if (is_static) {
@@ -447,7 +447,7 @@ int php_runkit_def_prop_remove_int(zend_class_entry *ce, zend_string *propname, 
 
 		if (property_info_ptr->flags & (ZEND_ACC_PRIVATE|ZEND_ACC_SHADOW)) {
 			if (offset >= 0) {
-				php_runkit_remove_overlapped_property_from_childs_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)),
+				php_runkit_remove_overlapped_property_from_childs_foreach(EG(class_table),
 				                               ce, propname, offset,
 				                               property_info_ptr->flags & ZEND_ACC_STATIC, remove_from_objects, property_info_ptr);
 			}

--- a/runkit_props.c
+++ b/runkit_props.c
@@ -31,7 +31,7 @@ runkit_property_modify() may be added in the future (will change the value, but 
 #ifdef PHP_RUNKIT_MANIPULATION_PROPERTIES
 
 /* {{{ php_runkit_make_object_property_public */
-static inline void php_runkit_make_object_property_public(zend_string *propname, zend_object *object, int offset, zend_property_info *property_info_ptr TSRMLS_DC) {
+static inline void php_runkit_make_object_property_public(zend_string *propname, zend_object *object, int offset, zend_property_info *property_info_ptr) {
 	if ((property_info_ptr->flags & (ZEND_ACC_PRIVATE | ZEND_ACC_PROTECTED | ZEND_ACC_SHADOW))) {
 		zval *prop_val = NULL;
 		if (!object->properties) {
@@ -50,7 +50,7 @@ static inline void php_runkit_make_object_property_public(zend_string *propname,
 			}
 			// TODO: This is probably going to cause a segfault.
 			zend_hash_update(object->properties, propname, prop_val);
-			php_error_docref(NULL TSRMLS_CC, E_NOTICE, "Making %s::%s public to remove it "
+			php_error_docref(NULL, E_NOTICE, "Making %s::%s public to remove it "
 					 "from class without objects overriding", ZSTR_VAL(object->ce->name), ZSTR_VAL(propname));
 		}
 	}
@@ -68,7 +68,7 @@ static void php_runkit_remove_children_def_props(zend_class_entry *ce, zend_clas
 	}
 
 	php_runkit_def_prop_remove_int(ce, pname, class_we_originally_removing_from, was_static, remove_from_objects,
-	                               parent_property TSRMLS_CC);
+	                               parent_property);
 }
 /* }}} */
 
@@ -96,7 +96,7 @@ static void php_runkit_remove_overlapped_property_from_childs_foreach(HashTable*
 		php_runkit_remove_overlapped_property_from_childs(ce, parent_class, propname, offset, is_static, remove_from_objects, property_info_ptr);
 	} ZEND_HASH_FOREACH_END();
 	// FIXME what was the intent of the original code?
-	// php_runkit_def_prop_add_int(ce, propname, property_info_ptr, access_type, (zend_string*) NULL, definer_class, override, override_in_objects TSRMLS_CC);
+	// php_runkit_def_prop_add_int(ce, propname, property_info_ptr, access_type, (zend_string*) NULL, definer_class, override, override_in_objects);
 }
 /* }}} */
 
@@ -113,7 +113,7 @@ static void php_runkit_remove_overlapped_property_from_childs(zend_class_entry *
 	}
 
 	php_runkit_remove_overlapped_property_from_childs_foreach(RUNKIT_53_TSRMLS_PARAM(EG(class_table)), ce, propname, offset, is_static, remove_from_objects, property_info_ptr);
-	// php_runkit_remove_property_from_reflection_objects(ce, propname TSRMLS_CC);
+	// php_runkit_remove_property_from_reflection_objects(ce, propname);
 
 	if (is_static) {
 		goto st_success;
@@ -122,7 +122,7 @@ static void php_runkit_remove_overlapped_property_from_childs(zend_class_entry *
 	PHP_RUNKIT_ITERATE_THROUGH_OBJECTS_STORE_BEGIN(i)
 		if (object->ce == ce) {
 			if (!remove_from_objects) {
-				php_runkit_make_object_property_public(propname, object, offset, property_info_ptr TSRMLS_CC);
+				php_runkit_make_object_property_public(propname, object, offset, property_info_ptr);
 			} else {
 				if (!Z_ISUNDEF(object->properties_table[offset])) {
 					if (!object->properties) {
@@ -146,7 +146,7 @@ st_success:
 	}
 	zend_hash_apply_with_argument(&ce->properties_info,
 								  php_runkit_remove_property_by_full_name,
-	                              property_info_ptr TSRMLS_CC);
+	                              property_info_ptr);
 	if ((p = zend_hash_find_ptr(&ce->properties_info, propname)) != NULL &&
 	    ZSTR_H(p->name) == ZSTR_H(property_info_ptr->name)) {
 		zend_hash_del(&ce->properties_info, propname);
@@ -157,7 +157,7 @@ st_success:
 /* {{{ php_runkit_def_prop_add_int */
 int php_runkit_def_prop_add_int(zend_class_entry *ce, zend_string* propname, zval *copyval, long visibility,
                                 zend_string* doc_comment, zend_class_entry *definer_class, int override,
-                                int override_in_objects TSRMLS_DC)
+                                int override_in_objects)
 {
 	uint32_t i;
 	int offset;
@@ -187,27 +187,27 @@ int php_runkit_def_prop_add_int(zend_class_entry *ce, zend_string* propname, zva
 	if ((prop_info_ptr = zend_hash_find_ptr(&ce->properties_info, propname)) != NULL) {
 		if (!override) {
 			zval_ptr_dtor(pcopyval);
-			php_error_docref(NULL TSRMLS_CC, E_NOTICE, "%s%s%s already exists, not adding",
+			php_error_docref(NULL, E_NOTICE, "%s%s%s already exists, not adding",
 			                 ZSTR_VAL(ce->name), (prop_info_ptr->flags & ZEND_ACC_STATIC) ? "::$" : "->", ZSTR_VAL(propname));
 			return FAILURE;
 		} else {
-			php_runkit_def_prop_remove_int(ce, propname, NULL, (zend_bool) 0, override_in_objects, (zend_property_info*) NULL TSRMLS_CC);
+			php_runkit_def_prop_remove_int(ce, propname, NULL, (zend_bool) 0, override_in_objects, (zend_property_info*) NULL);
 			php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 		}
 	}
 	prop_info_ptr = NULL;
 	zend_string_addref(propname);
 
-	if (zend_declare_property_ex(ce, propname, pcopyval, visibility, doc_comment TSRMLS_CC) == FAILURE) {
+	if (zend_declare_property_ex(ce, propname, pcopyval, visibility, doc_comment) == FAILURE) {
 		zval_ptr_dtor(pcopyval);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot declare new property");
+		php_error_docref(NULL, E_WARNING, "Cannot declare new property");
 		return FAILURE;
 	}
 
 	if (ce != definer_class) {
 		if (zend_hash_find(&ce->properties_info, propname) == NULL) {
 			zval_ptr_dtor(pcopyval);
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot find just added property's info");
+			php_error_docref(NULL, E_WARNING, "Cannot find just added property's info");
 			return FAILURE;
 		}
 		if (visibility & ZEND_ACC_PRIVATE) {
@@ -252,7 +252,7 @@ int php_runkit_def_prop_add_int(zend_class_entry *ce, zend_string* propname, zva
 
 	if (!prop_info_ptr && (prop_info_ptr = zend_hash_find_ptr(&ce->properties_info, propname)) == NULL) {
 		zval_ptr_dtor(pcopyval);
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Cannot find just added property's info");
+		php_error_docref(NULL, E_WARNING, "Cannot find just added property's info");
 		return FAILURE;
 	}
 	offset = prop_info_ptr->offset;
@@ -337,7 +337,7 @@ int php_runkit_def_prop_add_int(zend_class_entry *ce, zend_string* propname, zva
 /* {{{ php_runkit_def_prop_add
  */
 static int php_runkit_def_prop_add(zend_string *classname, zend_string *propname, zval *value,
-                                   long visibility, int override_in_objects TSRMLS_DC)
+                                   long visibility, int override_in_objects)
 {
 	zend_class_entry *ce;
 	zval *copyval;
@@ -348,7 +348,7 @@ static int php_runkit_def_prop_add(zend_string *classname, zend_string *propname
 	}
 
 	if (ce->type & ZEND_INTERNAL_CLASS) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Adding properties to internal classes is not allowed");
+		php_error_docref(NULL, E_WARNING, "Adding properties to internal classes is not allowed");
 		return FAILURE;
 	} else {
 		copyval = value;
@@ -357,15 +357,15 @@ static int php_runkit_def_prop_add(zend_string *classname, zend_string *propname
 	/* Check for existing property by this name */
 	/* Existing public? */
 	if ((existing_prop = zend_hash_find_ptr(&ce->properties_info, propname)) != NULL) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s%s%s already exists", ZSTR_VAL(classname),
+		php_error_docref(NULL, E_WARNING, "%s%s%s already exists", ZSTR_VAL(classname),
 		                 (existing_prop->flags & ZEND_ACC_STATIC) ? "::$" : "->", ZSTR_VAL(propname));
 		return FAILURE;
 	}
 
-	php_runkit_zval_resolve_class_constant(copyval, ce TSRMLS_CC);
+	php_runkit_zval_resolve_class_constant(copyval, ce);
 
 	if (php_runkit_def_prop_add_int(ce, propname, copyval, visibility, NULL, ce, 0,
-	                                override_in_objects TSRMLS_CC) != SUCCESS) {
+	                                override_in_objects) != SUCCESS) {
 		return FAILURE;
 	}
 
@@ -402,14 +402,14 @@ static inline void php_runkit_dump_hashtable_keys(HashTable* ht) {
 /* {{{ php_runkit_def_prop_remove_int */
 int php_runkit_def_prop_remove_int(zend_class_entry *ce, zend_string *propname, zend_class_entry *class_we_originally_removing_from,
                                    zend_bool was_static, zend_bool remove_from_objects,
-                                   zend_property_info *parent_property TSRMLS_DC)
+                                   zend_property_info *parent_property)
 {
 	// FIXME this should never be called until it is fixed.
 	uint32_t i;
 	int offset;
 	int flags;
 	zend_property_info *property_info_ptr;
-	php_error_docref(NULL TSRMLS_CC, E_ERROR, "php_runkit_def_prop_remove_int should not be called");
+	php_error_docref(NULL, E_ERROR, "php_runkit_def_prop_remove_int should not be called");
 
 	if ((property_info_ptr = zend_hash_find_ptr(&ce->properties_info, propname)) != NULL) {
 		if (class_we_originally_removing_from == NULL) {
@@ -461,13 +461,13 @@ int php_runkit_def_prop_remove_int(zend_class_entry *ce, zend_string *propname, 
 			} ZEND_HASH_FOREACH_END();
 		}
 
-		// php_runkit_remove_property_from_reflection_objects(ce, propname TSRMLS_CC);
+		// php_runkit_remove_property_from_reflection_objects(ce, propname);
 		php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
 	} else {
 		if (parent_property) {
 			return SUCCESS;
 		} else {
-			php_error_docref(NULL TSRMLS_CC, E_WARNING, "%s::%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(propname));
+			php_error_docref(NULL, E_WARNING, "%s::%s does not exist", ZSTR_VAL(ce->name), ZSTR_VAL(propname));
 			return FAILURE;
 		}
 	}
@@ -479,7 +479,7 @@ int php_runkit_def_prop_remove_int(zend_class_entry *ce, zend_string *propname, 
 	PHP_RUNKIT_ITERATE_THROUGH_OBJECTS_STORE_BEGIN(i)
 		if (object->ce == ce) {
 			if (!remove_from_objects) {
-				php_runkit_make_object_property_public(propname, object, offset, property_info_ptr TSRMLS_CC);
+				php_runkit_make_object_property_public(propname, object, offset, property_info_ptr);
 			} else {
 				if (!Z_ISUNDEF(object->properties_table[offset])) {
 					if (!object->properties) {
@@ -508,7 +508,7 @@ st_success:
 
 /* {{{ php_runkit_def_prop_remove */
 static int php_runkit_def_prop_remove(zend_string *classname, zend_string *propname,
-                                      zend_bool remove_from_objects TSRMLS_DC)
+                                      zend_bool remove_from_objects)
 {
 	zend_class_entry *ce;
 
@@ -517,18 +517,18 @@ static int php_runkit_def_prop_remove(zend_string *classname, zend_string *propn
 	}
 
 	if (ce->type & ZEND_INTERNAL_CLASS) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Removing properties from internal classes is not allowed");
+		php_error_docref(NULL, E_WARNING, "Removing properties from internal classes is not allowed");
 		return FAILURE;
 	}
 
 	php_runkit_clear_all_functions_runtime_cache(TSRMLS_C);
-	return php_runkit_def_prop_remove_int(ce, propname, NULL, 0, remove_from_objects, NULL TSRMLS_CC);
+	return php_runkit_def_prop_remove_int(ce, propname, NULL, 0, remove_from_objects, NULL);
 }
 /* }}} */
 
 /* {{{ php_runkit_remove_property_from_reflection_objects */
 /*
-void php_runkit_remove_property_from_reflection_objects(zend_class_entry *ce, zend_string *propname TSRMLS_DC) {
+void php_runkit_remove_property_from_reflection_objects(zend_class_entry *ce, zend_string *propname) {
 	uint32_t i;
 	extern PHPAPI zend_class_entry *reflection_property_ptr;
 
@@ -570,7 +570,7 @@ PHP_FUNCTION(runkit_default_property_add)
 
 	visibility = ZEND_ACC_PUBLIC;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SSz|l/", &classname, &propname,
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SSz|l/", &classname, &propname,
 	                          &value, &visibility) == FAILURE) {
 		RETURN_FALSE;
 	}
@@ -579,7 +579,7 @@ PHP_FUNCTION(runkit_default_property_add)
 
 	visibility &= ~PHP_RUNKIT_OVERRIDE_OBJECTS;
 
-	RETURN_BOOL(php_runkit_def_prop_add(classname, propname, value, visibility, override_in_objects TSRMLS_CC) == SUCCESS);
+	RETURN_BOOL(php_runkit_def_prop_add(classname, propname, value, visibility, override_in_objects) == SUCCESS);
 }
 /* }}} */
 
@@ -592,11 +592,11 @@ PHP_FUNCTION(runkit_default_property_remove)
 	zend_string *propname;
 	zend_bool remove_from_objects = 0;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "SS|b", &classname, &propname, &remove_from_objects) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|b", &classname, &propname, &remove_from_objects) == FAILURE) {
 		RETURN_FALSE;
 	}
 
-	RETURN_BOOL(php_runkit_def_prop_remove(classname, propname, remove_from_objects TSRMLS_CC) == SUCCESS);
+	RETURN_BOOL(php_runkit_def_prop_remove(classname, propname, remove_from_objects) == SUCCESS);
 }
 /* }}} */
 

--- a/runkit_sandbox.c
+++ b/runkit_sandbox.c
@@ -44,8 +44,7 @@ static zend_class_entry *php_runkit_sandbox_class_entry;
 
 #define PHP_RUNKIT_SANDBOX_BEGIN(objval) \
 { \
-	void *prior_context = tsrm_set_interpreter_context(objval->context); \
-	TSRMLS_FETCH();
+	void *prior_context = tsrm_set_interpreter_context(objval->context);
 
 #define PHP_RUNKIT_SANDBOX_ABORT(objval) \
 { \
@@ -876,7 +875,6 @@ static int php_runkit_sandbox_sapi_ub_write(const char *str, uint str_length)
 	tsrm_set_interpreter_context(objval->parent_context);
 	{
 		zval **output_buffer[1], *bufcopy, *retval = NULL;
-		TSRMLS_FETCH();
 
 		if (!objval->output_handler ||
 			!RUNKIT_IS_CALLABLE(objval->output_handler, IS_CALLABLE_CHECK_NO_ACCESS, NULL)) {
@@ -923,7 +921,6 @@ static int php_runkit_sandbox_sapi_ub_write(const char *str, uint str_length)
 static void php_runkit_sandbox_sapi_flush(void *server_context)
 {
 	php_runkit_sandbox_object *objval;
-	TSRMLS_FETCH();
 
 	objval = RUNKIT_G(current_sandbox);
 
@@ -938,7 +935,6 @@ static void php_runkit_sandbox_sapi_flush(void *server_context)
 	tsrm_set_interpreter_context(objval->parent_context);
 	{
 		zval *retval = NULL, **args[1];
-		TSRMLS_FETCH();
 
 		if (!objval->output_handler ||
 			!RUNKIT_IS_CALLABLE(objval->output_handler, IS_CALLABLE_CHECK_NO_ACCESS, NULL)) {
@@ -980,8 +976,6 @@ static struct stat *php_runkit_sandbox_sapi_get_stat()
 	if (objval) {
 		tsrm_set_interpreter_context(objval->parent_context);
 		{
-			TSRMLS_FETCH();
-
 			ret = php_runkit_sandbox_original_sapi.get_stat();
 		}
 		tsrm_set_interpreter_context(objval->context);
@@ -1003,8 +997,6 @@ static char *php_runkit_sandbox_sapi_getenv(char *name, size_t name_len)
 	if (objval) {
 		tsrm_set_interpreter_context(objval->parent_context);
 		{
-			TSRMLS_FETCH();
-
 			ret = php_runkit_sandbox_original_sapi.getenv(name, name_len);
 		}
 		tsrm_set_interpreter_context(objval->context);
@@ -1023,7 +1015,6 @@ static void php_runkit_sandbox_sapi_sapi_error(int type, const char *error_msg, 
 	char *message;
 	va_list args;
 	php_runkit_sandbox_object *objval;
-	TSRMLS_FETCH();
 
 	objval = RUNKIT_G(current_sandbox);
 
@@ -1034,8 +1025,6 @@ static void php_runkit_sandbox_sapi_sapi_error(int type, const char *error_msg, 
 	if (objval) {
 		tsrm_set_interpreter_context(objval->parent_context);
 		{
-			TSRMLS_FETCH();
-
 			php_runkit_sandbox_original_sapi.sapi_error(type, "%s", message);
 		}
 	} else {
@@ -1178,8 +1167,6 @@ static double php_runkit_sandbox_sapi_get_request_time()
  */
 static void php_runkit_sandbox_sapi_block_interruptions(void)
 {
-	TSRMLS_FETCH();
-
 	if (!RUNKIT_G(current_sandbox)) {
 		/* Not in a sandbox use SAPI's actual handler */
 		php_runkit_sandbox_original_sapi.block_interruptions();
@@ -1195,8 +1182,6 @@ static void php_runkit_sandbox_sapi_block_interruptions(void)
  */
 static void php_runkit_sandbox_sapi_unblock_interruptions(void)
 {
-	TSRMLS_FETCH();
-
 	if (!RUNKIT_G(current_sandbox)) {
 		/* Not in a sandbox use SAPI's actual handler */
 		php_runkit_sandbox_original_sapi.unblock_interruptions();
@@ -1668,8 +1653,6 @@ static void php_runkit_sandbox_dtor(php_runkit_sandbox_object *objval)
 
 	prior_context = tsrm_set_interpreter_context(objval->context);
 	{
-		TSRMLS_FETCH();
-
 		if (objval->disable_functions) {
 			efree(objval->disable_functions);
 		}
@@ -1823,8 +1806,6 @@ static void php_runkit_lint_compile(INTERNAL_FUNCTION_PARAMETERS, int filemode)
 	context = tsrm_new_interpreter_context();
 	prior_context = tsrm_set_interpreter_context(context);
 	// {
-	// 	TSRMLS_FETCH();
-
 	// 	php_request_startup();
 	// 	PG(during_request_startup) = 0;  // TODO find reason for workaround
 	// 	printf("######## Switched to another stack\n");

--- a/runkit_sandbox_parent.c
+++ b/runkit_sandbox_parent.c
@@ -62,24 +62,24 @@ typedef struct _php_runkit_sandbox_parent_object {
 	} \
 }
 
-#define PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(zval_p) (php_runkit_sandbox_parent_object*)zend_objects_get_address(zval_p TSRMLS_CC)
+#define PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(zval_p) (php_runkit_sandbox_parent_object*)zend_objects_get_address(zval_p)
 #define PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, pzv) \
 { \
 	objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(pzv); \
 \
 	if (!objval) { \
 		/* Should never ever happen.... */ \
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "HELP! HELP! MY PARENT HAS ABANDONED ME!"); \
+		php_error_docref(NULL, E_WARNING, "HELP! HELP! MY PARENT HAS ABANDONED ME!"); \
 		RETURN_FALSE; \
 	} \
 \
 	if (!objval->self->parent_access) { \
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to the parent has been suspended"); \
+		php_error_docref(NULL, E_WARNING, "Access to the parent has been suspended"); \
 		RETURN_FALSE; \
 	} \
 }
 
-static HashTable *php_runkit_sandbox_parent_resolve_symbol_table(php_runkit_sandbox_parent_object *objval TSRMLS_DC)
+static HashTable *php_runkit_sandbox_parent_resolve_symbol_table(php_runkit_sandbox_parent_object *objval)
 {
 	int i;
 	HashTable *oldActiveSymbolTable, *result;
@@ -169,13 +169,13 @@ PHP_METHOD(Runkit_Sandbox_Parent,__call)
 	zval *func_name, *args, *retval = NULL;
 	php_runkit_sandbox_parent_object *objval;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "za", &func_name, &args) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "za", &func_name, &args) == FAILURE) {
 		RETURN_NULL();
 	}
 
 	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
 	if (!objval->self->parent_call) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to call functions in the parent context is not enabled");
+		php_error_docref(NULL, E_WARNING, "Access to call functions in the parent context is not enabled");
 		RETURN_FALSE;
 	}
 
@@ -184,7 +184,7 @@ PHP_METHOD(Runkit_Sandbox_Parent,__call)
 		char *name = NULL;
 
 		if (!RUNKIT_IS_CALLABLE(func_name, IS_CALLABLE_CHECK_NO_ACCESS, &name)) {
-			php_error_docref1(NULL TSRMLS_CC, name, E_WARNING, "Function not defined");
+			php_error_docref1(NULL, name, E_WARNING, "Function not defined");
 			if (name) {
 				efree(name);
 			}
@@ -192,7 +192,7 @@ PHP_METHOD(Runkit_Sandbox_Parent,__call)
 			RETURN_FALSE;
 		}
 
-		php_runkit_sandbox_call_int(func_name, &name, &retval, args, return_value, prior_context TSRMLS_CC);
+		php_runkit_sandbox_call_int(func_name, &name, &retval, args, return_value, prior_context);
 	}
 	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
 
@@ -216,7 +216,7 @@ static void php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAMETE
 	int bailed_out = 0;
 	zval *retval = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "z", &zcode) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zcode) == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -224,11 +224,11 @@ static void php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAMETE
 
 	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
 	if (type == ZEND_EVAL && !objval->self->parent_eval) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to eval() code in the parent context is not enabled");
+		php_error_docref(NULL, E_WARNING, "Access to eval() code in the parent context is not enabled");
 		RETURN_FALSE;
 	}
 	if (type != ZEND_EVAL && !objval->self->parent_include) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to include()/include_once()/require()/require_once() in the parent context is not enabled");
+		php_error_docref(NULL, E_WARNING, "Access to include()/include_once()/require()/require_once() in the parent context is not enabled");
 		RETURN_FALSE;
 	}
 
@@ -238,7 +238,7 @@ static void php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAMETE
 		zend_op_array *op_array = NULL;
 		int already_included = 0;
 
-		op_array = php_runkit_sandbox_include_or_eval_int(return_value, zcode, type, once, &already_included TSRMLS_CC);
+		op_array = php_runkit_sandbox_include_or_eval_int(return_value, zcode, type, once, &already_included);
 
 		if (op_array) {
 			HashTable *old_symbol_table = EG(active_symbol_table);
@@ -247,9 +247,9 @@ static void php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAMETE
 
 			EG(return_value_ptr_ptr) = &retval;
 			EG(active_op_array) = op_array;
-			EG(active_symbol_table) = php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC);
+			EG(active_symbol_table) = php_runkit_sandbox_parent_resolve_symbol_table(objval);
 
-			zend_execute(op_array TSRMLS_CC);
+			zend_execute(op_array);
 
 			if (retval) {
 				*return_value = *retval;
@@ -257,7 +257,7 @@ static void php_runkit_sandbox_parent_include_or_eval(INTERNAL_FUNCTION_PARAMETE
 				RETVAL_TRUE;
 			}
 
-			destroy_op_array(op_array TSRMLS_CC);
+			destroy_op_array(op_array);
 			efree(op_array);
 
 			EG(return_value_ptr_ptr) = orig_retvalpp;
@@ -352,7 +352,7 @@ PHP_METHOD(Runkit_Sandbox_Parent,echo)
 
 	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
 	if (!objval->self->parent_echo) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to echo data in the parent context is not enabled");
+		php_error_docref(NULL, E_WARNING, "Access to echo data in the parent context is not enabled");
 		RETURN_FALSE;
 	}
 
@@ -375,13 +375,13 @@ PHP_METHOD(Runkit_Sandbox_Parent,print)
 	char *str;
 	int len;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s", &str, &len) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "s", &str, &len) == FAILURE) {
 		RETURN_FALSE;
 	}
 
 	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
 	if (!objval->self->parent_echo) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to echo data in the parent context is not enabled");
+		php_error_docref(NULL, E_WARNING, "Access to echo data in the parent context is not enabled");
 		RETURN_FALSE;
 	}
 
@@ -401,7 +401,7 @@ PHP_METHOD(Runkit_Sandbox_Parent,die)
 	php_runkit_sandbox_parent_object *objval;
 	zval *message = NULL;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "|z", &message) == FAILURE) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|z", &message) == FAILURE) {
 		RETURN_FALSE;
 	}
 
@@ -413,7 +413,7 @@ PHP_METHOD(Runkit_Sandbox_Parent,die)
 
 	PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX_VERIFY_ACCESS(objval, this_ptr);
 	if (!objval->self->parent_die) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Patricide is disabled.  Shame on you Oedipus.");
+		php_error_docref(NULL, E_WARNING, "Patricide is disabled.  Shame on you Oedipus.");
 		/* Sent as a warning, but we'll really implement it as an E_ERROR */
 		objval->self->active = 0;
 		RETURN_FALSE;
@@ -456,7 +456,7 @@ static zval *php_runkit_sandbox_parent_read_property(zval *object, zval *member,
 		return EG(uninitialized_zval_ptr);
 	}
 	if (!objval->self->parent_access || !objval->self->parent_read) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to read parent's symbol table is disallowed");
+		php_error_docref(NULL, E_WARNING, "Access to read parent's symbol table is disallowed");
 		return EG(uninitialized_zval_ptr);
 	}
 
@@ -465,7 +465,7 @@ static zval *php_runkit_sandbox_parent_read_property(zval *object, zval *member,
 	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
 		zval **value;
 
-		if ((value = zend_hash_str_find(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1)) != NULL) {
+		if ((value = zend_hash_str_find(php_runkit_sandbox_parent_resolve_symbol_table(objval), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1)) != NULL) {
 			retval = **value;
 			prop_found = 1;
 		}
@@ -475,7 +475,7 @@ static zval *php_runkit_sandbox_parent_read_property(zval *object, zval *member,
 		zval_dtor(member);
 	}
 
-	return php_runkit_sandbox_return_property_value(prop_found, &retval TSRMLS_CC);
+	return php_runkit_sandbox_return_property_value(prop_found, &retval);
 }
 /* }}} */
 
@@ -492,7 +492,7 @@ static void php_runkit_sandbox_parent_write_property(zval *object, zval *member,
 		return;
 	}
 	if (!objval->self->parent_access || !objval->self->parent_write) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to modify parent's symbol table is disallowed");
+		php_error_docref(NULL, E_WARNING, "Access to modify parent's symbol table is disallowed");
 		return;
 	}
 
@@ -504,7 +504,7 @@ static void php_runkit_sandbox_parent_write_property(zval *object, zval *member,
 		MAKE_STD_ZVAL(copyval);
 		*copyval = *value;
 		PHP_SANDBOX_CROSS_SCOPE_ZVAL_COPY_CTOR(copyval);
-		ZEND_SET_SYMBOL(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), copyval);
+		ZEND_SET_SYMBOL(php_runkit_sandbox_parent_resolve_symbol_table(objval), Z_STRVAL_P(member), copyval);
 	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
 
 	if (member == &tmp_member) {
@@ -524,14 +524,14 @@ static int php_runkit_sandbox_parent_has_property(zval *object, zval *member, in
 	int result = 0;
 
 	if (!objval || !objval->self->parent_access || !objval->self->parent_read) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to read parent's symbol table is disallowed");
+		php_error_docref(NULL, E_WARNING, "Access to read parent's symbol table is disallowed");
 		return 0;
 	}
 
 	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
 
 	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
-		php_runkit_sandbox_has_property_int(has_set_exists, member TSRMLS_CC);
+		php_runkit_sandbox_has_property_int(has_set_exists, member);
 	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
 
 	if (member == &member_copy) {
@@ -555,16 +555,16 @@ static void php_runkit_sandbox_parent_unset_property(zval *object, zval *member
 		return;
 	}
 	if (!objval->self->parent_access || !objval->self->parent_write) {
-		php_error_docref(NULL TSRMLS_CC, E_WARNING, "Access to modify parent's symbol table is disallowed");
+		php_error_docref(NULL, E_WARNING, "Access to modify parent's symbol table is disallowed");
 		return;
 	}
 
 	PHP_RUNKIT_ZVAL_CONVERT_TO_STRING_IF_NEEDED(member, member_copy);
 
 	PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval)
-		if (zend_hash_exists(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1)) {
+		if (zend_hash_exists(php_runkit_sandbox_parent_resolve_symbol_table(objval), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1)) {
 			/* Simply removing the zval* causes weirdness with CVs */
-			zend_hash_update(php_runkit_sandbox_parent_resolve_symbol_table(objval TSRMLS_CC), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void*)&EG(uninitialized_zval_ptr), sizeof(zval*), NULL);
+			zend_hash_update(php_runkit_sandbox_parent_resolve_symbol_table(objval), Z_STRVAL_P(member), Z_STRLEN_P(member) + 1, (void*)&EG(uninitialized_zval_ptr), sizeof(zval*), NULL);
 		}
 	PHP_RUNKIT_SANDBOX_PARENT_END(objval)
 
@@ -598,7 +598,7 @@ static zend_function_entry php_runkit_sandbox_parent_functions[] = {
 	{ NULL, NULL, NULL }
 };
 
-static void php_runkit_sandbox_parent_dtor(php_runkit_sandbox_parent_object *objval TSRMLS_DC)
+static void php_runkit_sandbox_parent_dtor(php_runkit_sandbox_parent_object *objval)
 {
 	zend_hash_destroy(objval->obj.properties);
 	FREE_HASHTABLE(objval->obj.properties);
@@ -606,7 +606,7 @@ static void php_runkit_sandbox_parent_dtor(php_runkit_sandbox_parent_object *obj
 	efree(objval);
 }
 
-static zend_object_value php_runkit_sandbox_parent_ctor(zend_class_entry *ce TSRMLS_DC)
+static zend_object_value php_runkit_sandbox_parent_ctor(zend_class_entry *ce)
 {
 	php_runkit_sandbox_parent_object *objval;
 	zend_object_value retval;
@@ -622,7 +622,7 @@ static zend_object_value php_runkit_sandbox_parent_ctor(zend_class_entry *ce TSR
 	}
 	ALLOC_HASHTABLE(objval->obj.properties);
 	zend_hash_init(objval->obj.properties, 0, NULL, ZVAL_PTR_DTOR, 0);
-	retval.handle = zend_objects_store_put(objval, NULL, (zend_objects_free_object_storage_t)php_runkit_sandbox_parent_dtor, NULL TSRMLS_CC);
+	retval.handle = zend_objects_store_put(objval, NULL, (zend_objects_free_object_storage_t)php_runkit_sandbox_parent_dtor, NULL);
 
 	retval.handlers = RUNKIT_G(current_sandbox) ? &php_runkit_sandbox_parent_handlers : zend_get_std_object_handlers();
 
@@ -634,7 +634,7 @@ int php_runkit_init_sandbox_parent(INIT_FUNC_ARGS)
 	zend_class_entry ce;
 
 	INIT_CLASS_ENTRY(ce, PHP_RUNKIT_SANDBOX_PARENT_CLASSNAME, php_runkit_sandbox_parent_functions);
-	php_runkit_sandbox_parent_entry = zend_register_internal_class(&ce TSRMLS_CC);
+	php_runkit_sandbox_parent_entry = zend_register_internal_class(&ce);
 	php_runkit_sandbox_parent_entry->create_object = php_runkit_sandbox_parent_ctor;
 
 	/* Make a new object handler struct with a couple minor changes */

--- a/runkit_sandbox_parent.c
+++ b/runkit_sandbox_parent.c
@@ -87,7 +87,7 @@ static HashTable *php_runkit_sandbox_parent_resolve_symbol_table(php_runkit_sand
 	zend_execute_data *ex = EG(current_execute_data);
 
 	if (!EG(active_symbol_table)) {
-		zend_rebuild_symbol_table(TSRMLS_C);
+		zend_rebuild_symbol_table();
 	}
 
 	if (objval->self->parent_scope <= 0) {
@@ -155,7 +155,7 @@ static HashTable *php_runkit_sandbox_parent_resolve_symbol_table(php_runkit_sand
 	EG(active_symbol_table) = NULL;
 	oldCurExData = EG(current_execute_data);
 	EG(current_execute_data) = ex;
-	zend_rebuild_symbol_table(TSRMLS_C);
+	zend_rebuild_symbol_table();
 	result = EG(active_symbol_table);
 	EG(active_symbol_table) = oldActiveSymbolTable;
 	EG(current_execute_data) = oldCurExData;
@@ -444,8 +444,7 @@ PHP_METHOD(Runkit_Sandbox_Parent,die)
 /* {{{ php_runkit_sandbox_parent_read_property
 	read_property handler */
 static zval *php_runkit_sandbox_parent_read_property(zval *object, zval *member, int type
-	, const zend_literal *key
-	TSRMLS_DC)
+	, const zend_literal *key)
 {
 	php_runkit_sandbox_parent_object *objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
 	zval tmp_member;
@@ -482,8 +481,7 @@ static zval *php_runkit_sandbox_parent_read_property(zval *object, zval *member,
 /* {{{ php_runkit_sandbox_parent_write_property
 	write_property handler */
 static void php_runkit_sandbox_parent_write_property(zval *object, zval *member, zval *value
-	, const zend_literal *key
-	TSRMLS_DC)
+	, const zend_literal *key)
 {
 	php_runkit_sandbox_parent_object *objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
 	zval tmp_member;
@@ -516,8 +514,7 @@ static void php_runkit_sandbox_parent_write_property(zval *object, zval *member,
 /* {{{ php_runkit_sandbox_parent_has_property
 	has_property handler */
 static int php_runkit_sandbox_parent_has_property(zval *object, zval *member, int has_set_exists
-	, const zend_literal *key
-	TSRMLS_DC)
+	, const zend_literal *key)
 {
 	php_runkit_sandbox_parent_object* objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
 	zval member_copy;
@@ -545,8 +542,7 @@ static int php_runkit_sandbox_parent_has_property(zval *object, zval *member, in
 /* {{{ php_runkit_sandbox_parent_unset_property
 	unset_property handler */
 static void php_runkit_sandbox_parent_unset_property(zval *object, zval *member
-	, const zend_literal *key
-	TSRMLS_DC)
+	, const zend_literal *key)
 {
 	php_runkit_sandbox_parent_object *objval = PHP_RUNKIT_SANDBOX_PARENT_FETCHBOX(object);
 	zval member_copy;

--- a/runkit_sandbox_parent.c
+++ b/runkit_sandbox_parent.c
@@ -43,7 +43,6 @@ typedef struct _php_runkit_sandbox_parent_object {
 #define PHP_RUNKIT_SANDBOX_PARENT_BEGIN(objval) \
 { \
 	void *prior_context = tsrm_set_interpreter_context(objval->self->parent_context); \
-	TSRMLS_FETCH(); \
 	zend_try {
 
 #define PHP_RUNKIT_SANDBOX_PARENT_ABORT(objval) \


### PR DESCRIPTION
Since this repo supports only php 7.0+, the code is easier to understand without these macros.

(php-src headers kept those macros only for backwards compatibility.)