### PR TITLE
Fixes incorrect reference counting of class names (in param/return type signatures) in php 7.2.0+

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,14 +12,14 @@ Define customized superglobal variables for general purpose use.
  </description>
  <lead>
   <name>Tyson Andre</name>
-  <user></user>
+  <user>tandre</user>
   <email></email>
   <active>yes</active>
  </lead>
- <date>2018-07-03</date>
+ <date>2018-07-04</date>
  <version>
-  <release>1.0.5b2</release>
-  <api>1.0.5b2</api>
+  <release>1.0.5b3</release>
+  <api>1.0.5b3</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -27,12 +27,8 @@ Define customized superglobal variables for general purpose use.
  </stability>
  <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
  <notes>
-- Fix compilation errors in newer php versions.
-- PHP 7.2+ continues to have some severe bugs for function/method manipulation
-- Fix some unit tests
-- runkit_lint and runkit_import continue to be broken (This release contains some work on trying to fix the compilation errors)
-- Update CI test scripts
-- Improve documentation
+- Fix incorrect reference counting of class names in parameter and return type signatures for `runkit_function_*()` and `runkit_method_*()` (https://github.com/runkit7/runkit7/issues/123).
+  This bug only affected php 7.2.0+
  </notes>
  <contents>
   <dir name="/">
@@ -210,6 +206,7 @@ Define customized superglobal variables for general purpose use.
     <file name="runkit_method_rename_and_reflection.phpt" role="test" />
     <file name="runkit_method_rename_inheritance.phpt" role="test" />
     <file name="runkit_method_rename.phpt" role="test" />
+    <file name="runkit_method_rename_repeated.phpt" role="test" />
     <file name="runkit_methods_redefining_and_cache.inc" role="test" />
     <file name="runkit_methods_redefining_and_cache.phpt" role="test" />
     <file name="runkit_methods_returning_by_reference.phpt" role="test" />
@@ -268,6 +265,22 @@ Define customized superglobal variables for general purpose use.
  <providesextension>runkit</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2018-07-04</date>
+   <version>
+    <release>1.0.5b3</release>
+    <api>1.0.5b3</api>
+   </version>
+   <stability>
+    <release>alpha</release>
+    <api>alpha</api>
+   </stability>
+   <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
+   <notes>
+- Fix incorrect reference counting of class names in parameter and return type signatures for `runkit_function_*()` and `runkit_method_*()` (https://github.com/runkit7/runkit7/issues/123).
+  This bug only affected php 7.2.0+
+   </notes>
+  </release>
   <release>
    <date>2018-07-03</date>
    <version>

--- a/tests/runkit_method_rename_repeated.phpt
+++ b/tests/runkit_method_rename_repeated.phpt
@@ -1,0 +1,30 @@
+--TEST--
+runkit_method_rename() function
+--SKIPIF--
+<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+--INI--
+display_errors=on
+--FILE--
+<?php
+class A {
+    public static function test() : BInstance{
+        return new BInstance();
+    }
+}
+class BInstance{}
+
+function main() {
+    var_export((string)(new ReflectionMethod('A', 'test'))->getReturnType());
+    runkit_method_copy('A', 'testbackup', 'A', 'test');
+    runkit_method_remove('A', 'test');
+    var_export((string)(new ReflectionMethod('A', 'testbackup'))->getReturnType());
+    runkit_method_copy('A', 'test', 'A', 'testbackup');
+    runkit_method_remove('A', 'testbackup');
+    var_export((string)(new ReflectionMethod('A', 'test'))->getReturnType());
+}
+main();
+main();
+main();
+main();
+--EXPECT--
+'BInstance''BInstance''BInstance''BInstance''BInstance''BInstance''BInstance''BInstance''BInstance''BInstance''BInstance''BInstance'


### PR DESCRIPTION
Fixes #123

Add a unit test of this failing