### PR TITLE
Work towards php 7.3 compatibility (still unusable for php 7.3 function/method manipulation)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   - CC=gcc-4.8 CXX=g++-4.8 USE_32BIT=1 VALGRIND=1 PHP_NTS_USE=actually-zts PHP_CONFIGURE_ARGS='--disable-all --enable-maintainer-zts --enable-debug --enable-session'
 
 # Defined at https://github.com/php-build/php-build/tree/master/share/php-build/definitions
+# https://github.com/travis-ci/travis-ci/issues/9717 PHP 7.3 alphas not added yet
 php:
   - master
   - '7.2'
@@ -36,8 +37,6 @@ matrix:
     - php: master
   exclude:
     - php: 7.0
-      env: CC=gcc-4.8 CXX=g++-4.8
-    - php: master
       env: CC=gcc-4.8 CXX=g++-4.8
     - php: master
       env: CC=gcc-4.8 CXX=g++-4.8 VALGRIND=1 PHP_NTS_USE=1 PHP_CONFIGURE_ARGS='--disable-all --disable-zts --enable-debug --enable-session'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ============================================================================================
 
 For all those things you.... probably shouldn't have been doing anyway.... but surely do!
-__Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipulation is recommended only for unit testing. **Does not work with PHP 7.3 yet**. [PHP 7.2 has some bugs in method/function manipulation that haven't been fixed yet.](https://github.com/runkit7/runkit7/issues/123) ).
+__Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipulation is recommended only for unit testing. **Does not work with PHP 7.3 yet**.
 
 [![Build Status](https://secure.travis-ci.org/runkit7/runkit7.png?branch=master)](http://travis-ci.org/runkit7/runkit7)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/3jwsf76ge0yo8v74/branch/master?svg=true)](https://ci.appveyor.com/project/TysonAndre/runkit7/branch/master)

--- a/tests/runkit_sandbox_with_register_globals.phpt
+++ b/tests/runkit_sandbox_with_register_globals.phpt
@@ -12,4 +12,3 @@ register_globals=On
 $php = new Runkit_Sandbox();
 --EXPECTREGEX--
 (((PHP )?Warning|Deprecated):\s+Directive 'register_globals' is deprecated in PHP 5\.3 and greater in Unknown on line 0)?(Fatal error: Directive 'register_globals' is no longer available in PHP in Unknown on line 0)?
---DONE--


### PR DESCRIPTION
Related to Issue #126 (This attempts to fix the way literals are allocated)

The way that constants get allocated or accessed seems to have changed.
Followup commits will be created to fix these