### PR TITLE
Release 1.0.6: Fix a crash in function/method manipulation in PHP 7.3a2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ============================================================================================
 
 For all those things you.... probably shouldn't have been doing anyway.... but surely do!
-__Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipulation is recommended only for unit testing. **Does not work with PHP 7.3 yet**.
+__Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipulation is recommended only for unit testing. (PHP 7.3 currently has minor bugs in `runkit_import` and internal function manipulation)
 
 [![Build Status](https://secure.travis-ci.org/runkit7/runkit7.png?branch=master)](http://travis-ci.org/runkit7/runkit7)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/3jwsf76ge0yo8v74/branch/master?svg=true)](https://ci.appveyor.com/project/TysonAndre/runkit7/branch/master)
@@ -10,11 +10,6 @@ __Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipula
 [Building and installing runkit in unix](#building-and-installing-runkit7-in-unix)
 
 [Building and installing runkit in Windows](#building-and-installing-runkit7-in-windows)
-
-Current Build Status
---------------------
-
-In 7.0.x and 7.1.x and 7.2.0: 0 failing tests, 4 expected failures (constant manipulation in same file), 61 skipped tests(for disabled property and import), and 95 passing tests.
 
 Compatibility: PHP7.0 to PHP 7.2
 --------------------------------

--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,8 @@ Define customized superglobal variables for general purpose use.
  </lead>
  <date>2018-07-04</date>
  <version>
-  <release>1.0.5b3</release>
-  <api>1.0.5b3</api>
+  <release>1.0.6</release>
+  <api>1.0.6</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -27,8 +27,7 @@ Define customized superglobal variables for general purpose use.
  </stability>
  <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
  <notes>
-- Fix incorrect reference counting of class names in parameter and return type signatures for `runkit_function_*()` and `runkit_method_*()` (https://github.com/runkit7/runkit7/issues/123).
-  This bug only affected php 7.2.0+
+- Fix crashes seen in php 7.3 alphas when function and method manipulation is used. (https://github.com/runkit7/runkit7/issues/126, https://github.com/runkit7/runkit7/issues/141)
  </notes>
  <contents>
   <dir name="/">
@@ -265,6 +264,21 @@ Define customized superglobal variables for general purpose use.
  <providesextension>runkit</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2018-07-04</date>
+   <version>
+    <release>1.0.6</release>
+    <api>1.0.6</api>
+   </version>
+   <stability>
+    <release>alpha</release>
+    <api>alpha</api>
+   </stability>
+   <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
+   <notes>
+- Fix crashes seen in php 7.3 alphas when function and method manipulation is used. (https://github.com/runkit7/runkit7/issues/126, https://github.com/runkit7/runkit7/issues/141)
+   </notes>
+  </release>
   <release>
    <date>2018-07-04</date>
    <version>

--- a/runkit_import.c
+++ b/runkit_import.c
@@ -613,6 +613,7 @@ PHP_FUNCTION(runkit_import)
 			zval *parent_name = RT_CONSTANT(new_op_array, new_op_array->opcodes[opline_num - 1].op2);
 			zval *key = parent_name + 1;
 			zend_class_entry *pce;
+			// TODO: Figure out why this assertion fails in php 7.3
 			ZEND_ASSERT(Z_TYPE_P(parent_name) == IS_STRING);
 
 			// TODO: Check if this is the same in php 7.0


### PR DESCRIPTION
Also, note that php 7.3 support still has some known bugs

Fixes #141