### PR TITLE
Fix an import error (of the parent) in php 7.3.0a2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ============================================================================================
 
 For all those things you.... probably shouldn't have been doing anyway.... but surely do!
-__Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipulation is recommended only for unit testing. (PHP 7.3 currently has minor bugs in `runkit_import` and internal function manipulation)
+__Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipulation is recommended only for unit testing)
 
 [![Build Status](https://secure.travis-ci.org/runkit7/runkit7.png?branch=master)](http://travis-ci.org/runkit7/runkit7)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/3jwsf76ge0yo8v74/branch/master?svg=true)](https://ci.appveyor.com/project/TysonAndre/runkit7/branch/master)
@@ -46,10 +46,10 @@ Class and function manipulation is recommended only for unit tests.
 
 The following contributions are welcome:
 
--	Pull requests with  PHP5 -> PHP7 code migration of functions
--	New test cases for features that no longer work in PHP7, or code crashing runkit7.
--	Issues for PHP language features that worked in PHP5, but no longer work in PHP7,
-	for the implemented methods (`runkit_function_*` and `runkit_method_*`)
+-   Pull requests with  PHP5 -> PHP7 code migration of functions
+-   New test cases for features that no longer work in PHP7, or code crashing runkit7.
+-   Issues for PHP language features that worked in PHP5, but no longer work in PHP7,
+    for the implemented methods (`runkit_function_*` and `runkit_method_*`)
 -   Fixes and documentation.
 
 Most of the runkit tests for method manipulation and function manipulation are passing.
@@ -69,46 +69,48 @@ The following mocking libraries work with the runkit7 fork
 
 ### Bugs in PHP7 runkit
 
--	There are segmentation faults when manipulating internal functions
-	(a.k.a. "runkit.internal_override=1")
-	(when you rename/redefine/(copy?) internal functions, and call internal functions with user functions' implementation, or vice versa)
-	(and when functions redefinitions aren't cleaned up)
-	Many of these have been fixed.
--	There are reference counting bugs causing memory leaks.
-	2 calls to `emalloc` have been temporarily replaced with calls to `pemalloc`
-	so that I could execute tests.
--	There may be a few remaining logic errors after migrating the code to PHP7.
--	The zend VM bytecode may change in 7.3 or future releases, so some opcodes may not work with each new minor php version release.
+-   There are segmentation faults when manipulating internal functions
+    (a.k.a. "runkit.internal_override=1")
+    (when you rename/redefine/(copy?) internal functions, and call internal functions with user functions' implementation, or vice versa)
+    (and when functions redefinitions aren't cleaned up)
+    Many of these have been fixed.
+-   There are reference counting bugs causing memory leaks.
+    2 calls to `emalloc` have been temporarily replaced with calls to `pemalloc`
+    so that I could execute tests.
+-   There may be a few remaining logic errors after migrating the code to PHP7.
+-   The zend VM bytecode representation may change in 7.3 betas or future minor/major releases,
+    so some opcodes may not work with each new minor php version release.
 
 ### APIs for PHP7
+
 #### Implemented APIs for PHP7 (buggy internal function manipulation):
 
--	`runkit_function_*`: Most tests are passing. There are some bugs related to renaming internal functions.
--	`runkit_method_*`: Most tests are passing. Same comment as `runkit_function_*`
--	`runkit_zval_inspect`: Partly passing, and needs to be rewritten because of PHP7's zval changes.
--	`runkit_constant_add` works. Other constant manipulation functions don't work for constants within the same file due to the interpreter inlining them.
--	Runkit superglobals.
+-   `runkit_function_*`: Most tests are passing. There are some memory leaks when renaming internal functions.
+-   `runkit_method_*`: Most tests are passing. There are some memory leaks when renaming internal functions.
+-   `runkit_zval_inspect`: Partly passing, and needs to be rewritten because of PHP7's zval changes.
+-   `runkit_constant_add` works. Other constant manipulation functions don't work for constants within the same file due to the interpreter inlining them.
+-   Runkit superglobals.
+-   `runkit_import`
+    Some flags are missing for PHP 7.x, especially properties, and other tests have known failures.
+    See https://github.com/runkit7/runkit7/issues/73
 
 #### Unsupported APIs for PHP7:
 (These functions will be missing. Some of these should be possible to implement.)
 
--	`runkit_import`
-	Disabled because of bugs related to properties
-	See https://github.com/runkit7/runkit7/issues/73
--	`runkit_class_adopt` and `runkit_class_emancipate`
-	Disabled because of [bugs related to properties](./PROPERTY_MANIPULATION.md).
--	`runkit_lint*`
+-   `runkit_class_adopt` and `runkit_class_emancipate`
+    Disabled because of [bugs related to properties](./PROPERTY_MANIPULATION.md).
+-   `runkit_lint*`
     Might be possible if this is rewritten to use actual threading: See [issue #114](https://github.com/runkit7/runkit7/issues/114)
--	`runkit_constant_*` : `runkit_constant_add` works reliably, other methods don't.
-	This works better when the constants are declared in a different file.
--	`runkit_default_property_*`
-	Disabled because of [bugs related to properties](./PROPERTY_MANIPULATION.md)
-	See [issue #30](https://github.com/runkit7/runkit7/issues/30) (implement function to modify only) and [issue #113](https://github.com/runkit7/runkit7/issues/113) (Manipulate static properties)
+-   `runkit_constant_*` : `runkit_constant_add` works reliably, other methods don't.
+    This works better when the constants are declared in a file separate from the file accessing that constant.
+-   `runkit_default_property_*`
+    Disabled because of [bugs related to properties](./PROPERTY_MANIPULATION.md)
+    See [issue #30](https://github.com/runkit7/runkit7/issues/30) (implement function to modify only) and [issue #113](https://github.com/runkit7/runkit7/issues/113) (Manipulate static properties)
 
-	`runkit_default_property_add` has been removed in php7 - it requires `realloc`ing a different zval to add a property to the property table
-	That would break a lot of things.
--	`runkit_return_value_used`: Removed, was not working and unrelated to other features.
-	`vld` seems to have a working implementation in the opcode analyzer, not familiar with how it works.
+    `runkit_default_property_add` has been removed in php7 - it requires `realloc`ing a different zval to add a property to the property table
+    That would break a lot of things.
+-   `runkit_return_value_used`: Removed, was not working and unrelated to other features.
+    `vld` seems to have a working implementation in the opcode analyzer, not familiar with how it works.
 
 #### Reasons for disabling property manipulation
 
@@ -118,16 +120,9 @@ See [PROPERTY\_MANIPULATION.md](./PROPERTY_MANIPULATION.md)
 
 See https://github.com/runkit7/runkit7/issues
 
-Things to do in the near future:
-
--   Fix bugs related to edge cases of function and method manipulation
--   See if constant manipulation in the same file can be fixed, e.g. by recompiling functions using those constants, or by patching php-src.
-    It was broken because the php7 compiler inlines the constants automatically in the generated opcodes.
-
-Things to do after that:
+Tasks for the near future:
 
 -   Replace property manipulation with `runkit_default_property_modify` (https://github.com/runkit7/runkit7/issues/30)
--	Fix FPM
 
 ### Contributing
 
@@ -183,24 +178,29 @@ User defined functions and user defined methods may now be renamed, delete, and 
 
 Examples for these functions may also be found in the tests folder.
 
+#### `runkit_lint` alternatives
+
+`runkit_lint` was  disabled with the rest of the sandbox code due to issues porting it to PHP 7 ([Issue #114](https://github.com/runkit7/runkit7/issues/114)).
 As a replacement for `runkit_lint`/`runkit_lint_file` try any of the following:
 
 - `php -l --no-php-ini $filename` will quickly check if a file is syntactically valid, but will not show you any php notices about deprecated code, etc.
 - [`opcache_compile_file`](https://secure.php.net/manual/en/function.opcache-compile-file.php) may help, but will not show you any notices.
 - [`token_get_all($code, TOKEN_PARSE)`](http://php.net/token_get_all) will detect invalid ASTs in php 7.0+
 - Projects such as [PHP-Parser (Pure PHP)](https://github.com/nikic/PHP-Parser) and [php-ast (C module)](https://github.com/nikic/php-ast), which produce an Abstract Syntax Tree from php code.
-  php-ast (PHP module) has a function is much faster and more accurate.
+  Alternately, `token_get_all()` will throw an error for syntax errors if the flag `TOKEN_PARSE` is passed in.
   (Unfortunately, it parses but does not detect erroneous code, e.g. duplicate classes/methods in the same file).
 
   ```php
   // Example replacement for runkit_lint.
   try {
-      $ast = ast\parse_code('<?php function foo(){}', $version = 35)
-	  return true;
-  }catch (ParseError $e) {
-	  return false;
+      $ast = token_get_all('<?php function foo(){}', TOKEN_PARSE)
+      return true;
+  } catch (ParseError $e) {
+      return false;
   }
   ```
+
+  Alternately, you may wish to use a different approach and run a PHP static analyzer such as [Phan](https://github.com/phan/phan), [Psalm](https://github.com/vimeo/psalm), or [PHPStan](https://github.com/phpstan/phpstan)
 
 Installation
 ============
@@ -224,8 +224,8 @@ sudo make install
 Pecl tars are also included with newer GitHub releases.
 
 1. Go to https://github.com/runkit7/runkit7/releases
-2. Download the tgz file from the link (e.g. runkit-1.0.5b1.tgz)
-3. `pecl install ./runkit-1.0.5b1.tgz`
+2. Download the tgz file from the link (e.g. runkit-1.0.6.tgz)
+3. `pecl install ./runkit-1.0.6.tgz`
 
 ### BUILDING AND INSTALLING RUNKIT7 IN WINDOWS
 
@@ -237,11 +237,14 @@ For PHP7, you need to install "Visual Studio 2015 Community Edition" (or other 2
 Make sure that C++ is installed with Visual Studio.
 The command prompt to use is "VS2015 x86 Native Tools Command Prompt" on 32-bit, "VS2015 x64 Native Tools Command Prompt" on 64-bit.
 
+- Note that different visual studio versions are recommended for different PHP versions.
+  For PHP 7.2+, use Visual Studio 2017 instead.
+
 For 64-bit installations of php7, use "x64" instead of "x86" for the below commands/folders.
 
 After completing setup steps mentioned, including for `C:\php-sdk\phpdev\vc14`
 
-extract download of php-7.0.9-src (or any version of php 7) to C:\php-sdk\phpdev\vc14\x86\php-7.0.9-src
+extract download of php-7.0.30-src (or any version of php 7) to C:\php-sdk\phpdev\vc14\x86\php-7.0.30-src
 
 #### Installing runkit7 on windows
 
@@ -256,13 +259,13 @@ Then, execute the following (Add `--enable-runkit` to the configure flags you we
 ```Batchfile
 cd C:\php-sdk
 C:\php-sdk\bin\phpsdk_setvars.bat
-cd phpdev\vc14\x86\php-7.0.9\src
+cd phpdev\vc14\x86\php-7.0.30\src
 buildconf
 configure --enable-runkit
 nmake
 ```
 
-Then, optionally test it (Most of the tests should pass, around 16 are still failing):
+Then, optionally test it (Most of the tests should pass, be skipped, or be known failures.):
 
 ```Batchfile
 nmake test TESTS="C:\php-sdk\vc14\x86\pecl\runkit7\tests

--- a/package.xml
+++ b/package.xml
@@ -18,8 +18,8 @@ Define customized superglobal variables for general purpose use.
  </lead>
  <date>2018-07-04</date>
  <version>
-  <release>1.0.6</release>
-  <api>1.0.6</api>
+  <release>1.0.7</release>
+  <api>1.0.7</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -264,6 +264,21 @@ Define customized superglobal variables for general purpose use.
  <providesextension>runkit</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2018-07-04</date>
+   <version>
+    <release>1.0.7</release>
+    <api>1.0.7</api>
+   </version>
+   <stability>
+    <release>alpha</release>
+    <api>alpha</api>
+   </stability>
+   <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
+   <notes>
+- Fix crashes in `runkit_import()` seen in php 7.3 alphas.
+   </notes>
+  </release>
   <release>
    <date>2018-07-04</date>
    <version>

--- a/runkit.h
+++ b/runkit.h
@@ -86,7 +86,7 @@ static inline void* _debug_emalloc(void* data, int bytes, char* file, int line) 
 #define debug_printf(...) do { } while(0)
 #endif
 
-#define PHP_RUNKIT_VERSION					"1.0.5b2"
+#define PHP_RUNKIT_VERSION					"1.0.7"
 #define PHP_RUNKIT_SANDBOX_CLASSNAME		"Runkit_Sandbox"
 #define PHP_RUNKIT_SANDBOX_PARENT_CLASSNAME	"Runkit_Sandbox_Parent"
 
@@ -614,7 +614,7 @@ inline static parsed_return_type php_runkit_parse_return_type_arg(int argc, zval
 }
 /* }}} */
 
-/* {{{ php_runkit_parse_return_type_arg */
+/* {{{ php_runkit_parse_is_strict_arg */
 inline static parsed_is_strict php_runkit_parse_is_strict_arg(int argc, zval *args, int arg_pos) {
 	parsed_is_strict retval;
 	retval.is_strict = 0;
@@ -634,6 +634,7 @@ inline static parsed_is_strict php_runkit_parse_is_strict_arg(int argc, zval *ar
 	}
 	return retval;
 }
+/* }}} */
 
 /* {{{ php_runkit_parse_args_to_zvals */
 inline static zend_bool php_runkit_parse_args_to_zvals(int argc, zval **pargs) {
@@ -744,6 +745,12 @@ inline static zend_object *php_runkit_zend_object_store_get(const zval *zobject)
 	return EG(objects_store).object_buckets[handle];
 }
 /* }}} */
+#endif
+
+#if PHP_VERSION_ID >= 70300
+#define RUNKIT_RT_CONSTANT(op_array, opline, node) RT_CONSTANT((opline), (node))
+#else
+#define RUNKIT_RT_CONSTANT(op_array, opline, node) RT_CONSTANT((op_array), (node))
 #endif
 
 #endif	/* RUNKIT_H */

--- a/runkit_functions.c
+++ b/runkit_functions.c
@@ -30,12 +30,6 @@
 #define RUNKIT_ALIASED_USER_FUNCTION(fe) ((fe)->internal_function.reserved[0])
 #define RUNKIT_IS_ALIAS_FOR_USER_FUNCTION(fe) ((fe)->type == ZEND_INTERNAL_FUNCTION && (fe)->internal_function.handler == php_runkit_function_alias_handler)
 
-#if PHP_VERSION_ID >= 70300
-#define RUNKIT_RT_CONSTANT(op_array, opline, node) RT_CONSTANT((opline), (node))
-#else
-#define RUNKIT_RT_CONSTANT(op_array, opline, node) RT_CONSTANT((op_array), (node))
-#endif
-
 extern ZEND_API void zend_vm_set_opcode_handler(zend_op* op);
 
 #ifdef PHP_RUNKIT_MANIPULATION

--- a/runkit_import.c
+++ b/runkit_import.c
@@ -26,7 +26,6 @@
 #include "runkit.h"
 #include "php_runkit_zval.h"
 
-// TODO: Actually implement this.
 #ifdef PHP_RUNKIT_MANIPULATION
 /* {{{ php_runkit_import_functions
  */
@@ -610,10 +609,10 @@ PHP_FUNCTION(runkit_import)
 		CG(in_compilation) = 1;
 		while (opline_num != (uint32_t)-1) {
 			// TODO: Check if it's still op2, figure out the set of expected opcodes
-			zval *parent_name = RT_CONSTANT(new_op_array, new_op_array->opcodes[opline_num - 1].op2);
+			const zend_op * const parent_name_opcode = &(new_op_array->opcodes[opline_num - 1]);
+			zval *parent_name = RUNKIT_RT_CONSTANT(new_op_array, parent_name_opcode, parent_name_opcode->op2);
 			zval *key = parent_name + 1;
 			zend_class_entry *pce;
-			// TODO: Figure out why this assertion fails in php 7.3
 			ZEND_ASSERT(Z_TYPE_P(parent_name) == IS_STRING);
 
 			// TODO: Check if this is the same in php 7.0

--- a/tests/runkit_function_variadic_strict.phpt
+++ b/tests/runkit_function_variadic_strict.phpt
@@ -50,7 +50,7 @@ function main() {
     try {
         printf("After mock: %s\n", var_export(bar('methodName', 0), true));
     } catch (TypeError $e) {
-        printf("When strict mode was true, this threw an exception: %s\n", $e->getMessage());
+        printf("When strict mode was true, this threw an exception: %s\n", str_replace('int,', 'integer,', $e->getMessage()));
     }
     remove_mock('bar', 'bar0000001123');
     printf("In weak mode\n");

--- a/tests/runkit_method_variadic_strict.phpt
+++ b/tests/runkit_method_variadic_strict.phpt
@@ -61,7 +61,7 @@ function main() {
     try {
         printf("After mock: %s\n", var_export(foo::bar('methodName', 0), true));
     } catch (TypeError $e) {
-        printf("When strict mode was true, this threw an exception: %s\n", $e->getMessage());
+        printf("When strict mode was true, this threw an exception: %s\n", str_replace('int,', 'integer,', $e->getMessage()));
     }
     remove_mock('foo', 'bar', 'bar0000001123');
     printf("In weak mode\n");


### PR DESCRIPTION
Forgot to update RT_CONSTANT to RUNKIT_RT_CONSTANT for php 7.3
compatibility there.

Follow up for #140

Release 1.0.7, update the current version

Fix README.md formatting, use spaces instead