### PR TITLE
Start testing with PHP 7.3, suppress test failures that are specific to PHP 7.3

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -56,22 +56,22 @@ environment:
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x64
                   VC: vc14
-                  PHP_VER: 7.1.22
+                  PHP_VER: 7.1.23
                   TS: 0
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
                   ARCH: x86
                   VC: vc14
-                  PHP_VER: 7.1.22
+                  PHP_VER: 7.1.23
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x64
                   VC: vc15
-                  PHP_VER: 7.2.10
+                  PHP_VER: 7.2.11
                   TS: 1
                 - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
                   ARCH: x86
                   VC: vc15
-                  PHP_VER: 7.2.10
+                  PHP_VER: 7.2.11
                   TS: 0
 
 build_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,10 @@ env:
 # TODO: Change master once Travis supports 7.3 as a tag (master is PHP 7.4-dev)
 php:
   - master
-  - '7.2'
-  - '7.1'
-  - '7.0'
+  - 7.3
+  - 7.2
+  - 7.1
+  - 7.0
 
 matrix:
   allow_failures:
@@ -39,6 +40,12 @@ matrix:
   exclude:
     - php: 7.0
       env: CC=gcc-4.8 CXX=g++-4.8
+    - php: 7.2
+      env: CC=gcc-4.8 CXX=g++-4.8
+    # Until https://bugs.php.net/bug.php?id=75951 is fixed for PHP 7.3 and master, exclude testing on clang since it won't build.
+    # This affects both the newer clang-5.0 and the default Travis version.
+    - php: 7.3
+      env: CC=clang
     - php: master
       env: CC=gcc-4.8 CXX=g++-4.8 VALGRIND=1 PHP_NTS_USE=1 PHP_CONFIGURE_ARGS='--disable-all --disable-zts --enable-debug --enable-session'
     - php: master
@@ -61,6 +68,8 @@ before_script:
 script:
  - phpenv config-rm xdebug.ini || true
  - ci/run_tests.sh
+ # Print any valgrind errors
+ - shopt -s nullglob; head -n 999 tests/*.mem < /dev/null
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ============================================================================================
 
 For all those things you.... probably shouldn't have been doing anyway.... but surely do!
-__Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipulation is recommended only for unit testing)
+__Now with partial support for PHP7.0, 7.1, 7.2, and 7.3!__ (function/method manipulation is recommended only for unit testing. Note that PHP 7.3 has known crashes in `runkit_import()` but other functionality works.)
 
 [![Build Status](https://secure.travis-ci.org/runkit7/runkit7.png?branch=master)](http://travis-ci.org/runkit7/runkit7)
 [![Build Status (Windows)](https://ci.appveyor.com/api/projects/status/3jwsf76ge0yo8v74/branch/master?svg=true)](https://ci.appveyor.com/project/TysonAndre/runkit7/branch/master)
@@ -11,7 +11,7 @@ __Now with partial support for PHP7.0, 7.1, and 7.2!__ (function/method manipula
 
 [Building and installing runkit in Windows](#building-and-installing-runkit7-in-windows)
 
-Compatibility: PHP7.0 to PHP 7.2
+Compatibility: PHP7.0 to PHP 7.3
 --------------------------------
 
 **See [runkit-api.php](./runkit-api.php) for the implemented functionality and method signatures.** New functionality was added to support usage with PHP7.
@@ -69,11 +69,12 @@ The following mocking libraries work with the runkit7 fork
 
 ### Bugs in PHP7 runkit
 
+-   There are segumentation faults in `runkit_import()` in PHP 7.3 (confirmed on NTS)
 -   There are segmentation faults when manipulating internal functions
     (a.k.a. "runkit.internal_override=1")
     (when you rename/redefine/(copy?) internal functions, and call internal functions with user functions' implementation, or vice versa)
     (and when functions redefinitions aren't cleaned up)
-    Many of these have been fixed.
+    Many (but not all) of these crashes have been fixed.
 -   There are reference counting bugs causing memory leaks.
     2 calls to `emalloc` have been temporarily replaced with calls to `pemalloc`
     so that tests would not crash during shutdown (and other reasons)

--- a/ci/install_php_nts.sh
+++ b/ci/install_php_nts.sh
@@ -25,12 +25,16 @@ if [ "x${TRAVIS:-0}" != "x" ]; then
 fi
 # Otherwise, put a minimal installation inside of the cache.
 PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-# TODO: Start testing 7.4 once travis CI supports PHP 7.3 instead of master
 if [ "$PHP_NTS_NORMAL_VERSION" == "7.3.0" || "$PHP_NTS_NORMAL_VERSION" == "7.4.0" ] ; then
-	curl --location --verbose https://github.com/php/php-src/archive/PHP-7.3.zip -o php-src-PHP-7.3.zip
-	unzip php-src-PHP-7.3.zip
-	PHP_FOLDER=php-src-PHP-7.3
-	pushd $PHP_FOLDER
+    if [ "$PHP_NTS_NORMAL_VERSION" == "7.3.0" ] ; then
+        GIT_BRANCH=7.3
+    else
+        GIT_BRANCH=master
+    fi
+    curl --location --verbose https://github.com/php/php-src/archive/PHP-$GIT_BRANCH.zip -o php-src-PHP-$GIT_BRANCH.zip
+    unzip php-src-PHP-$GIT_BRANCH.zip
+    PHP_FOLDER=php-src-$GIT_BRANCH
+    pushd $PHP_FOLDER
 	./buildconf --force
 	popd
 else

--- a/tests/bug4519.phpt
+++ b/tests/bug4519.phpt
@@ -1,7 +1,10 @@
 --TEST--
 Bug #4519 Unable to override class definitions of a derived class
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
+<?php
+if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
+elseif (PHP_VERSION_ID >= 70300) print "skip TODO Fix https://github.com/runkit7/runkit7/issues/135";
+?>
 --FILE--
 <?php
 class Foo extends Bar {
@@ -9,7 +12,7 @@ class Foo extends Bar {
 }
 
 class Bar {
-        function b() { print "Hello World from Bar!\n"; }
+    function b() { print "Hello World from Bar!\n"; }
 }
 
 

--- a/tests/runkit_fpm_internal_function_restore.phpt
+++ b/tests/runkit_fpm_internal_function_restore.phpt
@@ -16,7 +16,7 @@ echo _chop('A B '), "\n";
 echo __chop('C D '), "\n";
 echo "Test End\n";
 EOT;
-fpm_test(array($code, $code, $code), "-d extension_dir=modules/ -d extension=runkit.so -d runkit.internal_override=1");
+fpm_test(array($code, $code, $code), "-n -d extension_dir=modules/ -d extension=runkit.so -d runkit.internal_override=1");
 ?>
 Done
 --EXPECTF--

--- a/tests/runkit_import_class_extend.phpt
+++ b/tests/runkit_import_class_extend.phpt
@@ -3,8 +3,8 @@ runkit_import() Importing and overriding classes extending another loaded class
 --SKIPIF--
 <?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 if (!function_exists('runkit_import')) print "skip";
-if (DIRECTORY_SEPARATOR === "\\" && !ZEND_THREAD_SAFE) {
-	print "skip this is a known bug on windows and only affects NTS runkit_import(). https://github.com/runkit7/runkit7/issues/135 was filed to investigate this\n";
+if ((DIRECTORY_SEPARATOR === "\\" && !ZEND_THREAD_SAFE) || PHP_VERSION_ID >= 70300) {
+	print "skip this is a known bug on windows/PHP 7.3 and only affects NTS runkit_import(). https://github.com/runkit7/runkit7/issues/135 was filed to investigate this\n";
 }
 ?>
 --FILE--

--- a/tests/runkit_import_methods.phpt
+++ b/tests/runkit_import_methods.phpt
@@ -1,7 +1,12 @@
 --TEST--
 runkit_import() Importing and overriding class methods
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !function_exists('runkit_import')) print "skip"; ?>
+<?php
+if(!extension_loaded("runkit") || !function_exists('runkit_import')) print "skip";
+if ((DIRECTORY_SEPARATOR === "\\" && !ZEND_THREAD_SAFE) || PHP_VERSION_ID >= 70300) {
+	print "skip TODO: Fix PHP 7.3 NTS runkit_import(). https://github.com/runkit7/runkit7/issues/135 was filed to investigate this\n";
+}
+?>
 --FILE--
 <?php
 


### PR DESCRIPTION
This will make it obvious if future changes introduce new regressions.