### PR TITLE
Fix a crash after using runkit_function_rename

### DIFF
--- a/runkit_functions.c
+++ b/runkit_functions.c
@@ -1501,6 +1501,7 @@ PHP_FUNCTION(runkit_function_rename)
 		}
 		RETURN_FALSE;
 	}
+	php_runkit_fix_all_hardcoded_stack_sizes(dfunc_lower, func);
 
 	php_runkit_add_to_misplaced_internal_functions(func, dfunc_lower);
 

--- a/tests/runkit_function_rename_corruption.phpt
+++ b/tests/runkit_function_rename_corruption.phpt
@@ -1,0 +1,28 @@
+--TEST--
+runkit_function_rename() function corruption prevented when original method is replaced with a substitute.
+--SKIPIF--
+<?php if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if (!class_exists('SQLite3')) print "skip"; ?>
+--FILE--
+<?php
+
+function hi() {
+    echo "Hi";
+}
+
+function make_object() {
+    return new stdClass();
+}
+
+function fake_hi() {
+    $c = make_object();
+    var_dump($c);
+}
+
+runkit_function_rename('hi', 'hi5');
+runkit_function_rename('fake_hi', 'hi');
+
+hi();
+--EXPECTF--
+object(stdClass)#%d (0) {
+}

--- a/tests/runkit_function_rename_corruption2.phpt
+++ b/tests/runkit_function_rename_corruption2.phpt
@@ -1,0 +1,30 @@
+--TEST--
+runkit_function_rename() function corruption prevented when original method is replaced with a substitute.
+--SKIPIF--
+<?php if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if (!class_exists('SQLite3')) print "skip"; ?>
+--FILE--
+<?php
+
+function hi() {
+    echo "Hi";
+}
+
+function make_object() {
+    return new stdClass();
+}
+
+function fake_hi() {
+    $c = make_object();
+    var_dump($c);
+}
+
+runkit_function_rename('hi', 'hi5');
+
+try {
+	hi();
+} catch (Throwable $e) {
+	echo 'Caught ' . get_class($e) . ': ' . $e->getMessage();
+}
+--EXPECTF--
+Caught Error: Call to undefined function hi()


### PR DESCRIPTION
Fixes #153

The stack size could end up incorrect if runkit_function_rename was used
to replace the original removed/renamed function definition
with a different renamed function definition.

Unlike runkit_function_add and runkit_function_redefine,
the stack size fix wasn't getting applied for runkit_function_rename.

This PR fixes that by applying the fix to increase the maximum stack
size to be large enough for the **new** renamed definition of the
function, for anything that was referring to a different global function
definition with a potentially smaller stack size.