### PR TITLE
Small change for PHP 7.3 compiled with --enable-runkit-modify for Windows x64

### DIFF
--- a/runkit.c
+++ b/runkit.c
@@ -303,7 +303,7 @@ ZEND_FUNCTION(_php_runkit_removed_method)
 	php_error_docref(NULL, E_ERROR, "A method removed by runkit was somehow invoked");
 }
 
-static inline void _php_runkit_init_stub_function(const char *name, void (*handler)(INTERNAL_FUNCTION_PARAMETERS), zend_function **result)
+static inline void _php_runkit_init_stub_function(const char *name, ZEND_NAMED_FUNCTION(handler), zend_function **result)
 {
 	*result = pemalloc(sizeof(zend_function), 1);
 	(*result)->common.function_name = zend_string_init(name, strlen(name), 1);  // TODO: Can this be persistent?

--- a/runkit_functions.c
+++ b/runkit_functions.c
@@ -231,7 +231,7 @@ static void php_runkit_set_opcode_constant_relative(const zend_op_array *op_arra
 /* {{{ php_runkit_function_alias_handler
     Used when an internal function is replaced by a user-defined/runkit function. Converts the ICALL to a UCALL.
     Params: zend_execute_data *execute_data, zval *return_value */
-static void php_runkit_function_alias_handler(INTERNAL_FUNCTION_PARAMETERS)
+static ZEND_NAMED_FUNCTION(php_runkit_function_alias_handler)
 {
 	zend_function *fbc_inner;
 	zend_function *fbc = execute_data->func;


### PR DESCRIPTION
Back on bug #164, your advice allowed me to continue building runkit7 on Windows x64 for PHP 7.1, 7.2, 7.3. So thanks!

For 7.3, I ran into a few compile errors, similar to the following:

> error C2440: '==': cannot convert from 'void (__cdecl *)(zend_execute_data *,zval *)' to 'zif_handler'

The changes in this pull request allow me to compile against 7.3 x64 without those errors and pass the current test suite.  Warning: This is my first attempt at extension work, so this could totally be the wrong way to fix this.  Also, I didn't test 32-bit.

I've since noticed that you have a commit (88e2f6b) that addresses this in a different way, so this pull request is probably redundant.

These two links were helpful in figuring out what was wrong:
- https://externals.io/message/102338#102484
- https://github.com/m6w6/ext-http/commit/512f733beac73f37ba4acbcf730ebc6c6de849b6

If you want this applied against another branch, let me know.