### PR TITLE
Fix compilation and test errors in 7.4 and 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 # Defined at https://github.com/php-build/php-build/tree/master/share/php-build/definitions
 php:
   - master
-  - 7.4snapshot
+  - 7.4
   - 7.3
   - 7.2
   - 7.1
@@ -35,7 +35,7 @@ php:
 matrix:
   allow_failures:
     - php: master
-    - php: 7.4snapshot
+    - php: 7.4
   exclude:
     - php: 7.2
       env: CC=gcc-4.8 CXX=g++-4.8
@@ -43,9 +43,9 @@ matrix:
     # This affects both the newer clang-5.0 and the default Travis version.
     - php: 7.3
       env: CC=clang
-    - php: 7.4snapshot
+    - php: 7.4
       env: CC=gcc-4.8 CXX=g++-4.8 VALGRIND=1 PHP_NTS_USE=1 PHP_CONFIGURE_ARGS='--disable-all --disable-zts --enable-debug --enable-session'
-    - php: 7.4snapshot
+    - php: 7.4
       env: CC=clang
     - php: master
       env: CC=gcc-4.8 CXX=g++-4.8 VALGRIND=1 PHP_NTS_USE=1 PHP_CONFIGURE_ARGS='--disable-all --disable-zts --enable-debug --enable-session'

--- a/runkit_import.c
+++ b/runkit_import.c
@@ -477,6 +477,13 @@ void php_runkit_error_cb(int type, const char *error_filename, const uint error_
 */
 /* }}} */
 
+// Handle change to zend_build_delayed_early_binding_list in php 7.4
+#if PHP_VERSION_ID >= 70400
+#ifndef ZEND_DECLARE_INHERITED_CLASS_DELAYED
+#define ZEND_DECLARE_INHERITED_CLASS_DELAYED ZEND_DECLARE_CLASS_DELAYED
+#endif
+#endif
+
 uint32_t compute_early_binding_opline_num(const zend_op_array *op_array) /* {{{ */
 {
 #if PHP_VERSION_ID < 70300
@@ -606,7 +613,7 @@ PHP_FUNCTION(runkit7_import)
 			// TODO: Check if this is the same in php 7.0
             if (pce != NULL) {
 #if PHP_VERSION_ID >= 70400
-                do_bind_inherited_class(key, pce);
+                do_bind_class(key, Z_STR_P(parent_name));
 #else
                 do_bind_inherited_class(new_op_array, &new_op_array->opcodes[opline_num], tmp_class_table, pce, 0);
 #endif

--- a/tests/_fcgi.inc
+++ b/tests/_fcgi.inc
@@ -295,19 +295,19 @@ class Adoy_FastCGI_Client
         }
         $p = 0;
         while ($p != $length) {
-            $nlen = ord($data{$p++});
+            $nlen = ord($data[$p++]);
             if ($nlen >= 128) {
                 $nlen = ($nlen & 0x7F << 24);
-                $nlen |= (ord($data{$p++}) << 16);
-                $nlen |= (ord($data{$p++}) << 8);
-                $nlen |= (ord($data{$p++}));
+                $nlen |= (ord($data[$p++]) << 16);
+                $nlen |= (ord($data[$p++]) << 8);
+                $nlen |= (ord($data[$p++]));
             }
-            $vlen = ord($data{$p++});
+            $vlen = ord($data[$p++]);
             if ($vlen >= 128) {
                 $vlen = ($nlen & 0x7F << 24);
-                $vlen |= (ord($data{$p++}) << 16);
-                $vlen |= (ord($data{$p++}) << 8);
-                $vlen |= (ord($data{$p++}));
+                $vlen |= (ord($data[$p++]) << 16);
+                $vlen |= (ord($data[$p++]) << 8);
+                $vlen |= (ord($data[$p++]));
             }
             $array[substr($data, $p, $nlen)] = substr($data, $p+$nlen, $vlen);
             $p += ($nlen + $vlen);
@@ -323,12 +323,12 @@ class Adoy_FastCGI_Client
     private function decodePacketHeader($data)
     {
         $ret = array();
-        $ret['version']       = ord($data{0});
-        $ret['type']          = ord($data{1});
-        $ret['requestId']     = (ord($data{2}) << 8) + ord($data{3});
-        $ret['contentLength'] = (ord($data{4}) << 8) + ord($data{5});
-        $ret['paddingLength'] = ord($data{6});
-        $ret['reserved']      = ord($data{7});
+        $ret['version']       = ord($data[0]);
+        $ret['type']          = ord($data[1]);
+        $ret['requestId']     = (ord($data[2]) << 8) + ord($data[3]);
+        $ret['contentLength'] = (ord($data[4]) << 8) + ord($data[5]);
+        $ret['paddingLength'] = ord($data[6]);
+        $ret['reserved']      = ord($data[7]);
         return $ret;
     }
     /**
@@ -504,7 +504,7 @@ class Adoy_FastCGI_Client
         }
         // Reset timeout
         $this->set_ms_timeout($this->_readWriteTimeout);
-        switch (ord($resp['content']{4})) {
+        switch (ord($resp['content'][4])) {
             case self::CANT_MPX_CONN:
                 throw new Exception('This app can\'t multiplex [CANT_MPX_CONN]');
                 break;

--- a/tests/bug56662.phpt
+++ b/tests/bug56662.phpt
@@ -6,13 +6,13 @@ Bug#56662 - Wrong access level with RUNKIT_ACC_PUBLIC
 <?php
 class A {}
 runkit_method_add ('A', 'x', '', '', RUNKIT_ACC_PUBLIC);
-Reflection::export(new ReflectionMethod('A', 'x'));
+echo new ReflectionMethod('A', 'x') . "\n";
 
 class B extends A { public function x() {} }
-Reflection::export(new ReflectionMethod('B', 'x'));
+echo new ReflectionMethod('B', 'x') . "\n";
 
 eval("class C extends A { public function x() {} }");
-Reflection::export(new ReflectionMethod('C', 'x'));
+echo new ReflectionMethod('C', 'x');
 
 --EXPECTF--
 Method [ <user%S> public method x ] {

--- a/tests/runkit_method_add_overriding_parent_method.phpt
+++ b/tests/runkit_method_add_overriding_parent_method.phpt
@@ -1,11 +1,16 @@
 --TEST--
 runkit_method_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php
+if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip\n";
+if(PHP_VERSION_ID >= 80000) print "skip using parent in class with no parent\n";
+?>
 --INI--
 display_errors=on
+error_reporting = E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
+// TODO: Write an alternative test version that isn't an Error in php 8.0-dev
 class Class0 {
     function method3() {
         parent::method3();

--- a/tests/runkit_method_add_php73_bug.phpt
+++ b/tests/runkit_method_add_php73_bug.phpt
@@ -1,11 +1,16 @@
 --TEST--
 Bug in runkit_method_add (runkit7 issue #173)
 --SKIPIF--
-<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php
+if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip\n";
+if(PHP_VERSION_ID >= 80000) print "skip calls non-static method statically\n";
+?>
 --INI--
 display_errors=on
+error_reporting = E_ALL & ~E_DEPRECATED
 --FILE--
 <?php declare(strict_types=1);
+// Calling non-static method CacheWidget::_init_host statically is deprecated in php 7.4, suppressed E_DEPRECATED
 class Cache {
 
     private $_cacheWidget;

--- a/tests/runkit_method_remove.phpt
+++ b/tests/runkit_method_remove.phpt
@@ -1,7 +1,10 @@
 --TEST--
 runkit_method_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php
+if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip\n";
+if (PHP_VERSION_ID >= 80000) { print "skip\n";
+?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_remove_static.phpt
+++ b/tests/runkit_method_remove_static.phpt
@@ -1,0 +1,44 @@
+--TEST--
+runkit_method_remove() function
+--SKIPIF--
+<?php
+if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip\n";
+if (PHP_VERSION_ID >= 80000) { print "skip\n";
+?>
+--INI--
+display_errors=on
+--FILE--
+<?php
+ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT));
+
+class runkit_class {
+	static function runkit_method() {
+		echo "Runkit Method\n";
+	}
+	static function runkitMethod() {
+		echo "Runkit Method\n";
+	}
+}
+
+runkit_class::runkit_method();
+runkit_method_remove('runkit_class','runkit_method');
+if (!method_exists('runkit_class','runkit_method')) {
+	echo "Runkit Method Removed\n";
+}
+runkit_class::runkitMethod();
+runkit_method_remove('runkit_class','runkitMethod');
+if (!method_exists('runkit_class','runkitMethod')) {
+	echo "Runkit Method Removed\n";
+}
+runkit_class::runkitMethod();
+?>
+--EXPECTF--
+Runkit Method
+Runkit Method Removed
+Runkit Method
+Runkit Method Removed
+
+Fatal error: Uncaught Error: Call to undefined method runkit_class::runkitMethod() in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/tests/runkit_method_rename_repeated.phpt
+++ b/tests/runkit_method_rename_repeated.phpt
@@ -4,15 +4,16 @@ runkit_method_rename() function
 <?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
+error_reporting = E_ALL & ~E_DEPRECATED
 --FILE--
 <?php
+// ReflectionMethod::__toString was deprecated in php 7.4, and the deprecation is reversed in 8.0-dev. E_DEPRECATED is suppressed.
 class A {
     public static function test() : BInstance{
         return new BInstance();
     }
 }
 class BInstance{}
-
 function main() {
     var_export((string)(new ReflectionMethod('A', 'test'))->getReturnType());
     runkit_method_copy('A', 'testbackup', 'A', 'test');

--- a/tests/runkit_remove_magic_tostring_method.phpt
+++ b/tests/runkit_remove_magic_tostring_method.phpt
@@ -2,15 +2,16 @@
 removing magic __tostring method
 --SKIPIF--
 <?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+if (PHP_VERSION_ID >= 70400) print "skip";
 ?>
 --FILE--
 <?php
 class Test {
     function __tostring() {echo '__tostring';}
 }
-
 $a = new Test();
 (string) $a;
+// XXX what was this even testing, this was unreachable
 runkit_method_remove("Test", "__tostring");
 (string) $a;
 ?>

--- a/tests/runkit_remove_magic_tostring_method_php74.phpt
+++ b/tests/runkit_remove_magic_tostring_method_php74.phpt
@@ -1,0 +1,36 @@
+--TEST--
+removing magic __tostring method
+--SKIPIF--
+<?php
+if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+if (PHP_VERSION_ID < 70400) print "skip";
+?>
+--FILE--
+<?php
+class Test {
+    function __tostring() {echo "__tostring\n";}
+}
+
+$a = new Test();
+try {
+    (string) $a;
+} catch (Error $e) {
+    printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+}
+runkit_method_remove("Test", "__tostring");
+try {
+    (string) $a;
+} catch (Error $e) {
+    printf("Caught %s: %s\n", get_class($e), $e->getMessage());
+}
+runkit_method_add("Test", "__tostring", function () {
+	return 'a valid string';
+});
+$s = (string)$a;
+echo "Value: $s\n";
+?>
+--EXPECT--
+__tostring
+Caught Error: Method Test::__toString() must return a string value
+Caught Error: Object of class Test could not be converted to string
+Value: a valid string


### PR DESCRIPTION
Static variables, etc. are being copied incorrectly in
runkit_function_rename. ~~Those issues should be fixed before merging.~~

These issues seem to have been fixed.