### PR TITLE
3.0.0a1: Change shared object name to runkit7.so/php_runkit7.dll, change configure flags to --enable-runkit7

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,6 @@
 # Based on php-ast's appveyor config.
 # See https://github.com/nikic/php-ast/blob/master/.appveyor.yml
-# This tests against the multiple minor versions of PHP 7
+# This tests against multiple minor versions of PHP 7
 # Author: Tyson Andre
 
 version: '{branch}.{build}'
@@ -8,6 +8,7 @@ version: '{branch}.{build}'
 branches:
         only:
                 - master
+                - v3
 
 clone_folder:  c:\projects\runkit7
 
@@ -110,7 +111,7 @@ build_script:
                 echo "" | Out-File -Encoding "ASCII" task.bat
                 echo "call phpize 2>&1" | Out-File -Encoding "ASCII" -Append task.bat
                 # TODO: what is --enable-debug-pack
-                $cmd = 'call configure --enable-runkit --enable-runkit-spl_object_id --with-prefix=c:\build-cache\' + $dname + ' 2>&1'
+                $cmd = 'call configure --enable-runkit7 --enable-runkit7-spl_object_id --with-prefix=c:\build-cache\' + $dname + ' 2>&1'
                 echo $cmd | Out-File -Encoding "ASCII" -Append task.bat
                 echo "set REPORT_EXIT_STATUS=1" | Out-File -Encoding "ASCII" -Append task.bat
                 echo "set NO_INTERACTION=1" | Out-File -Encoding "ASCII" -Append task.bat

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
 
 before_script:
  - $CC --version && ci/print_php_int_max.php
- - (export CC; phpize && ./configure --enable-runkit-spl_object-id && make)
+ - (export CC; phpize && ./configure --enable-runkit7-spl_object-id && make)
 
 script:
  - phpenv config-rm xdebug.ini || true
@@ -77,6 +77,7 @@ script:
 branches:
   only:
     - master
+    - v3
 
 notifications:
  email: false

--- a/Makefile.frag
+++ b/Makefile.frag
@@ -1,0 +1,30 @@
+install: $(all_targets) $(install_targets) show-install-instructions
+
+show-install-instructions:
+	@echo
+	@$(top_srcdir)/build/shtool echo -n -e %B
+	@echo   "  +----------------------------------------------------------------------+"
+	@echo   "  |                                                                      |"
+	@echo   "  |   UPGRADING NOTICE                                                   |"
+	@echo   "  |   ================                                                   |"
+	@echo   "  |                                                                      |"
+	@echo   "  |   In runkit7 v3, the name of the installed shared library has been   |"
+	@echo   "  |   changed from \"runkit\" to \"runkit7\".                                |"
+	@echo   "  |   (i.e. runkit.so changed to runkit7.so, and php_runkit.dll changed  |"
+	@echo   "  |   to php_runkit7.dll)                                                |"
+	@echo   "  |                                                                      |"
+	@echo   "  |   - php.ini files WILL NEED TO BE CHANGED TO LOAD RUNKIT7 INSTEAD.   |"
+	@echo   "  |                                                                      |"
+	@echo   "  |   Additionally, the configuration flags used have changed from       |"
+	@echo   "  |   --enable-runkit-feature to --enable-runkit7-feature.               |"
+	@echo   "  |                                                                      |"
+	@echo   "  |   This change was made to comply with PECL's naming/packaging        |"
+	@echo   "  |   guidelines.                                                        |"
+	@echo   "  |                                                                      |"
+	@echo   "  +----------------------------------------------------------------------+"
+	@$(top_srcdir)/build/shtool echo -n -e %b
+	@echo
+	@echo
+
+findphp:
+	@echo $(PHP_EXECUTABLE)

--- a/UPGRADING_TO_3.md
+++ b/UPGRADING_TO_3.md
@@ -1,0 +1,15 @@
+Upgrading from runkit7 2.x to 3.0
+=================================
+
+Runkit7 3.0 finishes changing this extension's name from "runkit" to "runkit7".
+THIS WILL REQUIRE CHANGES TO YOUR BUILD SCRIPTS AND PHP.INI FILES.
+This change was made at the request of PECL admins, to comply with naming and packaging standards.
+
+- The compiled shared object name has been changed from `runkit.so` to `runkit7.so` (Mac/Linux) and `php_runkit.dll` to `php_runkit7.dll` (Windows)
+  (php.ini files should be changed to reference `extension=runkit7.so` or `extension=php_runkit7.dll`)
+- The configure flag names have been changed from flags such as `--enable-runkit` / `--enable-runkit-modify` to `--enable-runkit7` / `--enable-runkit7-modify`
+- Code using `extension_loaded('runkit')` should be changed to `extension_loaded('runkit7')` (as well as uses of ReflectionExtension, etc.)
+- The ini options `runkit.superglobal` and `runkit.internal_override` are unaffected.
+
+Other changes:
+- Classkit compatibility functions/constants have been removed.

--- a/config.m4
+++ b/config.m4
@@ -1,22 +1,21 @@
-dnl $Id$
-dnl config.m4 for extension runkit
+dnl config.m4 for extension runkit7
 
-PHP_ARG_ENABLE(runkit, whether to enable runkit support,
-[  --enable-runkit           Enable runkit support], no, yes)
+PHP_ARG_ENABLE(runkit7, whether to enable runkit7 support,
+[  --enable-runkit7          Enable runkit7 support], no, yes)
 
-PHP_ARG_ENABLE(runkit-modify, whether to enable runtime manipulation of functions/classes/constants,
-[  --enable-runkit-modify    Enable runtime manipulation], inherit, no)
+PHP_ARG_ENABLE(runkit7-modify, whether to enable runtime manipulation of functions/classes/constants,
+[  --enable-runkit7-modify    Enable runtime manipulation], inherit, no)
 
-PHP_ARG_ENABLE(runkit-super, whether to enable registration of user-defined autoglobals,
-[  --enable-runkit-super     Enable registration of user-defined autoglobals], inherit, no)
+PHP_ARG_ENABLE(runkit7-super, whether to enable registration of user-defined autoglobals,
+[  --enable-runkit7-super     Enable registration of user-defined autoglobals], inherit, yes)
 
-PHP_ARG_ENABLE(runkit_spl_object_id, whether to enable spl_object_id in PHP <= 7.1,
-[  --enable-runkit-spl_object_id    Enable spl_object_id support], no, no)
+PHP_ARG_ENABLE(runkit7_spl_object_id, whether to enable spl_object_id in PHP <= 7.1,
+[  --enable-runkit7-spl_object_id    Enable spl_object_id support], no, no)
 
-dnl PHP_ARG_ENABLE(runkit-sandbox, whether to enable Sandbox support,
-dnl [  --enable-runkit-sandbox   Enable Runkit_Sandbox (Requires ZTS)], inherit, no)
+dnl PHP_ARG_ENABLE(runkit7-sandbox, whether to enable Sandbox support,
+dnl [  --enable-runkit7-sandbox   Enable Runkit_Sandbox (Requires ZTS)], inherit, no)
 
-if test "$PHP_RUNKIT" != "no"; then
+if test "$PHP_RUNKIT7" != "no"; then
   AC_MSG_CHECKING([if this is built with PHP >= 7.1])
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
   #include <$phpincludedir/main/php_version.h>
@@ -29,50 +28,39 @@ if test "$PHP_RUNKIT" != "no"; then
   ],[
     AC_MSG_ERROR([Runkit7 requires PHP 7.1 or newer, phpize was run with PHP < 7.1]);
   ])
-  if test "$PHP_RUNKIT_SUPER" = "inherit"; then
-    PHP_RUNKIT_SUPER=yes
+  if test "$PHP_RUNKIT7_SUPER" = "inherit"; then
+    PHP_RUNKIT7_SUPER=yes
   fi
-dnl  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
-dnl    PHP_RUNKIT_SANDBOX=yes
+dnl  if test "$PHP_RUNKIT7_SANDBOX" = "inherit"; then
+dnl    PHP_RUNKIT7_SANDBOX=yes
 dnl  fi
 else
-  if test "$PHP_RUNKIT_MODIFY" = "inherit"; then
-    PHP_RUNKIT_MODIFY=no
+  if test "$PHP_RUNKIT7_MODIFY" = "inherit"; then
+    PHP_RUNKIT7_MODIFY=no
   fi
-  if test "$PHP_RUNKIT_SUPER" = "inherit"; then
-    PHP_RUNKIT_SUPER=no
+  if test "$PHP_RUNKIT7_SUPER" = "inherit"; then
+    PHP_RUNKIT7_SUPER=no
   fi
-dnl  if test "$PHP_RUNKIT_SANDBOX" = "inherit"; then
-dnl    PHP_RUNKIT_SANDBOX=no
+dnl  if test "$PHP_RUNKIT7_SANDBOX" = "inherit"; then
+dnl    PHP_RUNKIT7_SANDBOX=no
 dnl  fi
 fi
 
-dnl   test "$PHP_RUNKIT_SANDBOX" = "yes" ||
-if test "$PHP_RUNKIT_MODIFY" = "yes" ||
-   test "$PHP_RUNKIT_SUPER" = "yes"; then
-  if test "$PHP_RUNKIT" != "classkit"; then
-    PHP_RUNKIT=yes
+if test "$PHP_RUNKIT7" != "no"; then
+  if test "$PHP_RUNKIT7_MODIFY" != "no"; then
+    AC_DEFINE(PHP_RUNKIT7_FEATURE_MODIFY, 1, [Whether to export runtime modification features])
   fi
-fi
-
-if test "$PHP_RUNKIT" != "no"; then
-  if test "$PHP_RUNKIT" = "classkit"; then
-    AC_DEFINE(PHP_RUNKIT_CLASSKIT_COMPAT, 1, [Whether to export classkit compatible function aliases])
+  if test "$PHP_RUNKIT7_SUPER" != "no"; then
+    AC_DEFINE(PHP_RUNKIT7_FEATURE_SUPER, 1, [Whether to export custom autoglobal registration feature])
   fi
-  if test "$PHP_RUNKIT_MODIFY" != "no"; then
-    AC_DEFINE(PHP_RUNKIT_FEATURE_MODIFY, 1, [Whether to export runtime modification features])
-  fi
-  if test "$PHP_RUNKIT_SUPER" != "no"; then
-    AC_DEFINE(PHP_RUNKIT_FEATURE_SUPER, 1, [Whether to export custom autoglobal registration feature])
-  fi
-dnl  if test "$PHP_RUNKIT_SANDBOX" != "no"; then
-dnl    AC_DEFINE(PHP_RUNKIT_FEATURE_SANDBOX, 1, [Whether to export Sandbox feature])
+dnl  if test "$PHP_RUNKIT7_SANDBOX" != "no"; then
+dnl    AC_DEFINE(PHP_RUNKIT7_FEATURE_SANDBOX, 1, [Whether to export Sandbox feature])
 dnl  fi
-  if test "$PHP_RUNKIT_SPL_OBJECT_ID" != "no"; then
-    AC_DEFINE(PHP_RUNKIT_SPL_OBJECT_ID, 1, [Whether to define spl_object_id in php <= 7.1])
+  if test "$PHP_RUNKIT7_SPL_OBJECT_ID" != "no"; then
+    AC_DEFINE(PHP_RUNKIT7_SPL_OBJECT_ID, 1, [Whether to define spl_object_id in php <= 7.1])
   fi
 dnl runkit_sandbox.c runkit_sandbox_parent.c
-  PHP_NEW_EXTENSION(runkit, runkit.c runkit_functions.c runkit_methods.c \
+  PHP_NEW_EXTENSION(runkit7, runkit.c runkit_functions.c runkit_methods.c \
 runkit_import.c \
 runkit_constants.c \
 runkit_object_id.c \

--- a/config.w32
+++ b/config.w32
@@ -9,7 +9,7 @@ ARG_ENABLE("runkit7-spl_object_id", "Enable spl_object_id alias of runkit_object
 // The sandbox and the associated code was disabled for php 7.
 // ARG_ENABLE("runkit7-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
 
-if (PHP_RUNKIT77 != "no") {
+if (PHP_RUNKIT7 != "no") {
     var dll = get_define('PHPDLL');
     var is_php5 = null != dll.match(/^php5/);
     if (is_php5) {

--- a/config.w32
+++ b/config.w32
@@ -1,43 +1,44 @@
 // vim:ft=javascript
+/* eslint-disable no-undef */
 
-ARG_ENABLE("runkit", "Enable runkit support", "no");
-ARG_ENABLE("runkit-modify", "Enable runtime manipulation", "yes");
-ARG_ENABLE("runkit-super", "Enable registration of user-defined autoglobals", "yes");
-ARG_ENABLE("runkit-spl_object_id", "Enable spl_object_id alias of runkit_object_id in php <= 7.1", "no");
+ARG_ENABLE("runkit7", "Enable runkit7 support", "no");
+ARG_ENABLE("runkit7-modify", "Enable runtime manipulation", "yes");
+ARG_ENABLE("runkit7-super", "Enable registration of user-defined autoglobals", "yes");
+ARG_ENABLE("runkit7-spl_object_id", "Enable spl_object_id alias of runkit_object_id in php <= 7.1", "no");
 
 // The sandbox and the associated code was disabled for php 7.
-// ARG_ENABLE("runkit-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
+// ARG_ENABLE("runkit7-sandbox", "Disable Runkit_Sandbox (Requires ZTS)", "yes");
 
-if (PHP_RUNKIT != "no") {
+if (PHP_RUNKIT77 != "no") {
     var dll = get_define('PHPDLL');
     var is_php5 = null != dll.match(/^php5/);
     if (is_php5) {
-        ERROR("Runkit7 supports PHP 7 and newer. It does not support PHP 5");
+        ERROR("Runkit7 supports PHP 7.1 and newer. It does not support PHP 5");
     }
 
     // TODO: Why isn't HAVE_CONFIG_H being set all of the time?
-    if (PHP_RUNKIT_MODIFY != "no") {
+    if (PHP_RUNKIT7_MODIFY != "no") {
         // Hackish way to enable these CFLAGS to include the necessary flags
-        ADD_FLAG('CFLAGS_RUNKIT', ' /D PHP_RUNKIT_FEATURE_MODIFY');
-        AC_DEFINE("PHP_RUNKIT_FEATURE_MODIFY", 1, "Runkit Manipulation");
+        ADD_FLAG('CFLAGS_RUNKIT7', ' /D PHP_RUNKIT7_FEATURE_MODIFY');
+        AC_DEFINE("PHP_RUNKIT7_FEATURE_MODIFY", 1, "Runkit Manipulation");
     }
-    if (PHP_RUNKIT_SUPER != "no") {
-        ADD_FLAG('CFLAGS_RUNKIT', ' /D PHP_RUNKIT_FEATURE_SUPER');
-        AC_DEFINE("PHP_RUNKIT_FEATURE_SUPER", 1, "Runkit Superglobals");
+    if (PHP_RUNKIT7_SUPER != "no") {
+        ADD_FLAG('CFLAGS_RUNKIT7', ' /D PHP_RUNKIT7_FEATURE_SUPER');
+        AC_DEFINE("PHP_RUNKIT7_FEATURE_SUPER", 1, "Runkit Superglobals");
     }
-    if (PHP_RUNKIT_SPL_OBJECT_ID != "no") {
-        ADD_FLAG('CFLAGS_RUNKIT', ' /D PHP_RUNKIT_SPL_OBJECT_ID');
-        AC_DEFINE("PHP_RUNKIT_SPL_OBJECT_ID", 1, "Runkit spl_object_id substitute");
+    if (PHP_RUNKIT7_SPL_OBJECT_ID != "no") {
+        ADD_FLAG('CFLAGS_RUNKIT7', ' /D PHP_RUNKIT7_SPL_OBJECT_ID');
+        AC_DEFINE("PHP_RUNKIT7_SPL_OBJECT_ID", 1, "Runkit spl_object_id substitute");
     }
 
 
-    // AC_DEFINE("PHP_RUNKIT_FEATURE_SANDBOX", PHP_RUNKIT_SANDBOX != "no", "Runkit Sandbox");
+    // AC_DEFINE("PHP_RUNKIT7_FEATURE_SANDBOX", PHP_RUNKIT7_SANDBOX != "no", "Runkit Sandbox");
 
-    AC_DEFINE('HAVE_RUNKIT', 1);
+    AC_DEFINE('HAVE_RUNKIT7', 1);
 
-    PHP_INSTALL_HEADERS('ext/runkit', 'php_runkit.h php_runkit_hash.h php_runkit_zend_execute_API.h php_runkit_zval.h runkit.h');
+    PHP_INSTALL_HEADERS('ext/runkit7', 'php_runkit7.h php_runkit_hash.h php_runkit_zend_execute_API.h php_runkit_zval.h runkit.h');
 
-    EXTENSION("runkit", "runkit.c " +
+    EXTENSION("runkit7", "runkit.c " +
                         "runkit_common.c " +
                         "runkit_functions.c " +
                         "runkit_methods.c " +

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,8 @@ Define customized superglobal variables for general purpose use.
  </lead>
  <date>2019-05-29</date>
  <version>
-  <release>2.1.0</release>
-  <api>2.1.0</api>
+  <release>3.0.0a1</release>
+  <api>3.0.0</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -26,8 +26,19 @@ Define customized superglobal variables for general purpose use.
  </stability>
  <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
  <notes>
-- Add runkit7_*() aliases for runkit_*() global functions.
-- Add RUNKIT7_* aliases for RUNKIT_* global constants.
+Runkit7 3.0 finishes changing this extension's name from "runkit" to "runkit7".
+THIS WILL REQUIRE CHANGES TO YOUR BUILD SCRIPTS AND PHP.INI FILES.
+This change was made at the request of PECL admins, to comply with naming and packaging standards.
+
+- The compiled shared object name has been changed from `runkit.so` to `runkit7.so` (Mac/Linux) and `php_runkit.dll` to `php_runkit7.dll` (Windows)
+  (php.ini files should be changed to reference `extension=runkit7.so` or `extension=php_runkit7.dll`)
+- The configure flag names have been changed from flags such as `--enable-runkit` / `--enable-runkit-modify` to `--enable-runkit7` / `--enable-runkit7-modify`
+- Code using `extension_loaded('runkit')` should be changed to `extension_loaded('runkit7')` (as well as uses of ReflectionExtension, etc.)
+- The ini options `runkit.superglobal` and `runkit.internal_override` are unaffected.
+
+Other changes:
+- It is now possible to disable superglobal support (--disable-runkit7-super was fixed)
+- Classkit compatibility functions/constants have been removed.
  </notes>
  <contents>
   <dir name="/">
@@ -251,8 +262,9 @@ Define customized superglobal variables for general purpose use.
    </dir> <!-- //tests -->
    <file name="config.m4" role="src" />
    <file name="config.w32" role="src" />
+   <file name="Makefile.frag" role="src" />
    <file name="runkit.h" role="src" />
-   <file name="php_runkit.h" role="src" />
+   <file name="php_runkit7.h" role="src" />
    <file name="php_runkit_hash.h" role="src" />
    <file name="php_runkit_zend_execute_API.h" role="src" />
    <file name="php_runkit_zval.h" role="src" />
@@ -260,6 +272,7 @@ Define customized superglobal variables for general purpose use.
    <file name="LICENSE.ZEND" role="doc" />
    <file name="PROPERTY_MANIPULATION.md" role="doc" />
    <file name="README.md" role="doc" />
+   <file name="UPGRADING_TO_3.md" role="doc" />
    <file name="runkit.c" role="src" />
    <file name="runkit_classes.c" role="src" />
    <file name="runkit_common.c" role="src" />
@@ -282,9 +295,36 @@ Define customized superglobal variables for general purpose use.
    </pearinstaller>
   </required>
  </dependencies>
- <providesextension>runkit</providesextension>
+ <providesextension>runkit7</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2019-05-29</date>
+   <version>
+    <release>3.0.0a1</release>
+    <api>3.0.0</api>
+   </version>
+   <stability>
+    <release>alpha</release>
+    <api>alpha</api>
+   </stability>
+   <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
+   <notes>
+Runkit7 3.0 finishes changing this extension's name from "runkit" to "runkit7".
+THIS WILL REQUIRE CHANGES TO YOUR BUILD SCRIPTS AND PHP.INI FILES.
+This change was made at the request of PECL admins, to comply with naming and packaging standards.
+
+- The compiled shared object name has been changed from `runkit.so` to `runkit7.so` (Mac/Linux) and `php_runkit.dll` to `php_runkit7.dll` (Windows)
+  (php.ini files should be changed to reference `extension=runkit7.so` or `extension=php_runkit7.dll`)
+- The configure flag names have been changed from flags such as `--enable-runkit` / `--enable-runkit-modify` to `--enable-runkit7` / `--enable-runkit7-modify`
+- Code using `extension_loaded('runkit')` should be changed to `extension_loaded('runkit7')` (as well as uses of ReflectionExtension, etc.)
+- The ini options `runkit.superglobal` and `runkit.internal_override` are unaffected.
+
+Other changes:
+- It is now possible to disable superglobal support (--disable-runkit7-super was fixed)
+- Classkit compatibility functions/constants have been removed.
+   </notes>
+  </release>
   <release>
    <date>2019-05-29</date>
    <version>

--- a/php_runkit7.h
+++ b/php_runkit7.h
@@ -17,14 +17,11 @@
   +----------------------------------------------------------------------+
 */
 
-#ifndef PHP_RUNKIT_H
-#define PHP_RUNKIT_H
+#ifndef PHP_RUNKIT7_H
+#define PHP_RUNKIT7_H
 
-#ifndef phpext_runkit_ptr
-extern zend_module_entry runkit_module_entry;
-#define phpext_runkit_ptr &runkit_module_entry
+#ifndef phpext_runkit7_ptr
+extern zend_module_entry runkit7_module_entry;
+#define phpext_runkit7_ptr &runkit7_module_entry
 #endif
-
-// TODO: Move function declarations back here?
-// TODO: Change the name of this (and the ifdef) to php_runkit7.h if the DSO name changes
-#endif	/* PHP_RUNKIT_H */
+#endif	/* PHP_RUNKIT7_H */

--- a/php_runkit_hash.h
+++ b/php_runkit_hash.h
@@ -64,7 +64,7 @@ inline static void php_runkit_hash_move_runkit_to_front()
 {
 	zend_ulong numkey;
 	zend_string *strkey;
-	zend_string *runkit_str;
+	zend_string *runkit7_str;
 	dtor_func_t oldPDestructor;
 	zend_module_entry *module;
 	int num = 0;
@@ -75,23 +75,23 @@ inline static void php_runkit_hash_move_runkit_to_front()
 	}
 	RUNKIT_G(module_moved_to_front) = 1;
 
-	runkit_str = zend_string_init("runkit", sizeof("runkit") - 1, 0);
+	runkit7_str = zend_string_init("runkit7", sizeof("runkit7") - 1, 0);
 	// 1. If runkit is not part of the module registry, warn and do nothing.
-	if (!zend_hash_exists(&module_registry, runkit_str)) {
-		php_error_docref(NULL, E_WARNING, "Failed to find \"runkit\" module when attempting to change module unloading order - The lifetime of internal function overrides will be unexpected");
-		zend_string_release(runkit_str);
+	if (!zend_hash_exists(&module_registry, runkit7_str)) {
+		php_error_docref(NULL, E_WARNING, "Failed to find \"runkit7\" module when attempting to change module unloading order - The lifetime of internal function overrides will be unexpected");
+		zend_string_release(runkit7_str);
 		return;
 	}
 	// php_error_docref(NULL, E_WARNING, "In php_runkit_hash_move_to_front size=%d", (int)zend_hash_num_elements(&module_registry));
 
-	// 2. Create a temporary table with "runkit" at the front.
+	// 2. Create a temporary table with "runkit7" at the front.
 	ZEND_HASH_FOREACH_KEY_PTR(&module_registry, numkey, strkey, module) {
 		// php_error_docref(NULL, E_WARNING, "In php_runkit_hash_move_to_front numkey=%d strkey=%s refcount=%d zv=%llx", (int)numkey, strkey != NULL ? ZSTR_VAL(strkey) : "null", (int)(strkey != NULL ? zend_string_refcount(strkey) : 0), (long long) (uintptr_t)module);
 		if (num++ == 0) {
 			zend_bool first_is_core = 0;
 			Bucket *b;
 			zend_hash_init(&tmp, zend_hash_num_elements(&module_registry), NULL, NULL, 0);
-			// add "core" first, then "runkit", then the remaining modules.
+			// add "core" first, then "runkit7", then the remaining modules.
 			// If core isn't first, core tries to free the memory of strings that runkit allocated.
 			first_is_core = strkey != NULL && zend_string_equals_literal(strkey, "core");
 			if (first_is_core) {
@@ -100,7 +100,7 @@ inline static void php_runkit_hash_move_runkit_to_front()
 				php_error_docref(NULL, E_WARNING, "unexpected module order: \"core\" isn't first");
 			}
 			// Otherwise, initialize the temporary table (with no destructor function)
-			b = php_runkit_zend_hash_find_bucket(&module_registry, runkit_str);
+			b = php_runkit_zend_hash_find_bucket(&module_registry, runkit7_str);
 
 			zend_hash_add_ptr(&tmp, b->key, Z_PTR(b->val));
 			if (first_is_core) {
@@ -108,8 +108,8 @@ inline static void php_runkit_hash_move_runkit_to_front()
 			}
 		}
 		if (strkey != NULL) {
-			if (zend_string_equals(runkit_str, strkey)) {
-				// Already added persistent string for "runkit" to the front.
+			if (zend_string_equals(runkit7_str, strkey)) {
+				// Already added persistent string for "runkit7" to the front.
 				continue;
 			}
 			zend_hash_add_ptr(&tmp, strkey, module);
@@ -117,8 +117,8 @@ inline static void php_runkit_hash_move_runkit_to_front()
 			zend_hash_index_add_ptr(&tmp, numkey, module);
 		}
 	} ZEND_HASH_FOREACH_END();
-	zend_string_release(runkit_str);
-	runkit_str = NULL;
+	zend_string_release(runkit7_str);
+	runkit7_str = NULL;
 
 	oldPDestructor = module_registry.pDestructor;
 	module_registry.pDestructor = NULL;

--- a/runkit.c
+++ b/runkit.c
@@ -20,7 +20,7 @@
 #include "runkit.h"
 #include "SAPI.h"
 
-ZEND_DECLARE_MODULE_GLOBALS(runkit)
+ZEND_DECLARE_MODULE_GLOBALS(runkit7)
 
 #ifdef PHP_RUNKIT_SUPERGLOBALS
 /* {{{ proto array runkit7_superglobals(void)
@@ -238,9 +238,9 @@ PHP_FUNCTION(runkit7_lint);
 PHP_FUNCTION(runkit7_lint_file);
 #endif
 
-/* {{{ runkit_functions[]
+/* {{{ runkit7_functions[]
  */
-zend_function_entry runkit_functions[] = {
+zend_function_entry runkit7_functions[] = {
 
 	PHP_FE_AND_FALIAS(runkit_zval_inspect, 		runkit7_zval_inspect,		arginfo_runkit_zval_inspect)
 	PHP_FE_AND_FALIAS(runkit_object_id,			runkit7_object_id,			arginfo_runkit_object_id)
@@ -269,15 +269,6 @@ zend_function_entry runkit_functions[] = {
 	PHP_FE_AND_FALIAS(runkit_method_rename,				runkit7_method_rename,	arginfo_runkit_method_rename)
 	PHP_FE_AND_FALIAS(runkit_method_copy,				runkit7_method_copy,	arginfo_runkit_method_copy)
 
-#ifdef PHP_RUNKIT_CLASSKIT_COMPAT
-	PHP_FALIAS(classkit_method_add,			runkit7_method_add,		arginfo_runkit_method_add)
-	PHP_FALIAS(classkit_method_redefine,	runkit7_method_redefine,	arginfo_runkit_method_redefine)
-	PHP_FALIAS(classkit_method_remove,		runkit7_method_remove,	arginfo_runkit_method_remove)
-	PHP_FALIAS(classkit_method_rename,		runkit7_method_rename,	arginfo_runkit_method_rename)
-	PHP_FALIAS(classkit_method_copy,		runkit7_method_copy,		arginfo_runkit_method_copy)
-	PHP_FALIAS(classkit_import,				runkit7_import,			arginfo_runkit_import)
-#endif
-
 	PHP_FE_AND_FALIAS(runkit_constant_redefine,				runkit7_constant_redefine,	arginfo_runkit_constant_redefine)
 	PHP_FE_AND_FALIAS(runkit_constant_remove,				runkit7_constant_remove,	arginfo_runkit_constant_remove)
 	PHP_FE_AND_FALIAS(runkit_constant_add,				runkit7_constant_add,	arginfo_runkit_constant_add)
@@ -301,18 +292,18 @@ zend_function_entry runkit_functions[] = {
 };
 /* }}} */
 
-/* {{{ runkit_module_entry
+/* {{{ runkit7_module_entry
  */
-zend_module_entry runkit_module_entry = {
+zend_module_entry runkit7_module_entry = {
 	STANDARD_MODULE_HEADER,
-	"runkit",
-	runkit_functions,
-	PHP_MINIT(runkit),
-	PHP_MSHUTDOWN(runkit),
-	PHP_RINIT(runkit),
-	PHP_RSHUTDOWN(runkit),
-	PHP_MINFO(runkit),
-	PHP_RUNKIT_VERSION,
+	"runkit7",
+	runkit7_functions,
+	PHP_MINIT(runkit7),
+	PHP_MSHUTDOWN(runkit7),
+	PHP_RINIT(runkit7),
+	PHP_RSHUTDOWN(runkit7),
+	PHP_MINFO(runkit7),
+	PHP_RUNKIT7_VERSION,
 	STANDARD_MODULE_PROPERTIES
 };
 /* }}} */
@@ -323,23 +314,23 @@ PHP_INI_BEGIN()
 	PHP_INI_ENTRY("runkit.superglobal", "", PHP_INI_SYSTEM | PHP_INI_PERDIR, NULL)
 #endif
 #ifdef PHP_RUNKIT_MANIPULATION
-	STD_PHP_INI_BOOLEAN("runkit.internal_override", "0", PHP_INI_SYSTEM, OnUpdateBool, internal_override, zend_runkit_globals, runkit_globals)
+	STD_PHP_INI_BOOLEAN("runkit.internal_override", "0", PHP_INI_SYSTEM, OnUpdateBool, internal_override, zend_runkit7_globals, runkit7_globals)
 #endif
 PHP_INI_END()
 #endif
 
-#ifdef COMPILE_DL_RUNKIT
-ZEND_GET_MODULE(runkit)
+#ifdef COMPILE_DL_RUNKIT7
+ZEND_GET_MODULE(runkit7)
 #endif
 
 #ifdef PHP_RUNKIT_MANIPULATION
 ZEND_FUNCTION(_php_runkit_removed_function)
 {
-	php_error_docref(NULL, E_ERROR, "A function removed by runkit was somehow invoked");
+	php_error_docref(NULL, E_ERROR, "A function removed by runkit7 was somehow invoked");
 }
 ZEND_FUNCTION(_php_runkit_removed_method)
 {
-	php_error_docref(NULL, E_ERROR, "A method removed by runkit was somehow invoked");
+	php_error_docref(NULL, E_ERROR, "A method removed by runkit7 was somehow invoked");
 }
 
 static inline void _php_runkit_init_stub_function(const char *name, ZEND_NAMED_FUNCTION(handler), zend_function **result)
@@ -353,14 +344,14 @@ static inline void _php_runkit_init_stub_function(const char *name, ZEND_NAMED_F
 	(*result)->common.fn_flags = ZEND_ACC_PUBLIC | ZEND_ACC_STATIC;
 	(*result)->common.arg_info = NULL;
 	(*result)->internal_function.handler = handler;
-	(*result)->internal_function.module = &runkit_module_entry;
+	(*result)->internal_function.module = &runkit7_module_entry;
 }
 #endif
 
 #if defined(PHP_RUNKIT_SANDBOX) || defined(PHP_RUNKIT_MANIPULATION)
-static void php_runkit_globals_ctor(void *pDest)
+static void php_runkit7_globals_ctor(void *pDest)
 {
-	zend_runkit_globals *runkit_global = (zend_runkit_globals *)pDest;
+	zend_runkit7_globals *runkit_global = (zend_runkit7_globals *)pDest;
 #ifdef PHP_RUNKIT_SANDBOX
 	runkit_global->current_sandbox = NULL;
 #endif
@@ -385,15 +376,15 @@ static void php_runkit_globals_ctor(void *pDest)
 
 /* {{{ PHP_MINIT_FUNCTION
  */
-PHP_MINIT_FUNCTION(runkit)
+PHP_MINIT_FUNCTION(runkit7)
 {
 #ifdef ZTS
 #if defined(PHP_RUNKIT_SANDBOX) || defined(PHP_RUNKIT_MANIPULATION)
-	ts_allocate_id(&runkit_globals_id, sizeof(zend_runkit_globals), php_runkit_globals_ctor, NULL);
+	ts_allocate_id(&runkit7_globals_id, sizeof(zend_runkit7_globals), php_runkit7_globals_ctor, NULL);
 #endif
 #else
 #if defined(PHP_RUNKIT_SANDBOX) || defined(PHP_RUNKIT_MANIPULATION)
-	php_runkit_globals_ctor(&runkit_globals);
+	php_runkit7_globals_ctor(&runkit7_globals);
 #endif
 #endif
 
@@ -408,8 +399,8 @@ PHP_MINIT_FUNCTION(runkit)
 	REGISTER_RUNKIT7_LONG_CONSTANT("RUNKIT_IMPORT_CLASS_STATIC_PROPS", "RUNKIT7_IMPORT_CLASS_STATIC_PROPS", PHP_RUNKIT_IMPORT_CLASS_STATIC_PROPS);
 	REGISTER_RUNKIT7_LONG_CONSTANT("RUNKIT_IMPORT_CLASSES", "RUNKIT7_IMPORT_CLASSES", PHP_RUNKIT_IMPORT_CLASSES);
 	REGISTER_RUNKIT7_LONG_CONSTANT("RUNKIT_IMPORT_OVERRIDE", "RUNKIT7_IMPORT_OVERRIDE", PHP_RUNKIT_IMPORT_OVERRIDE);
-	REGISTER_STRING_CONSTANT("RUNKIT_VERSION", PHP_RUNKIT_VERSION, CONST_CS | CONST_PERSISTENT);
-	REGISTER_STRING_CONSTANT("RUNKIT7_VERSION", PHP_RUNKIT_VERSION, CONST_CS | CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("RUNKIT_VERSION", PHP_RUNKIT7_VERSION, CONST_CS | CONST_PERSISTENT);
+	REGISTER_STRING_CONSTANT("RUNKIT7_VERSION", PHP_RUNKIT7_VERSION, CONST_CS | CONST_PERSISTENT);
 
 	REGISTER_RUNKIT7_LONG_CONSTANT("RUNKIT_ACC_RETURN_REFERENCE", "RUNKIT7_ACC_RETURN_REFERENCE", PHP_RUNKIT_ACC_RETURN_REFERENCE);
 
@@ -418,14 +409,6 @@ PHP_MINIT_FUNCTION(runkit)
 	REGISTER_RUNKIT7_LONG_CONSTANT("RUNKIT_ACC_PRIVATE", "RUNKIT7_ACC_PRIVATE", ZEND_ACC_PRIVATE);
 	REGISTER_RUNKIT7_LONG_CONSTANT("RUNKIT_ACC_STATIC", "RUNKIT7_ACC_STATIC", ZEND_ACC_STATIC);
 	REGISTER_RUNKIT7_LONG_CONSTANT("RUNKIT_OVERRIDE_OBJECTS", "RUNKIT7_OVERRIDE_OBJECTS", PHP_RUNKIT_OVERRIDE_OBJECTS);
-
-#ifdef PHP_RUNKIT_CLASSKIT_COMPAT
-	REGISTER_LONG_CONSTANT("CLASSKIT_ACC_PUBLIC",              ZEND_ACC_PUBLIC,                         CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("CLASSKIT_ACC_PROTECTED",           ZEND_ACC_PROTECTED,                      CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("CLASSKIT_ACC_PRIVATE",             ZEND_ACC_PRIVATE,                        CONST_CS | CONST_PERSISTENT);
-	REGISTER_STRING_CONSTANT("CLASSKIT_VERSION",               PHP_RUNKIT_VERSION,                      CONST_CS | CONST_PERSISTENT);
-	REGISTER_LONG_CONSTANT("CLASSKIT_AGGREGATE_OVERRIDE",      PHP_RUNKIT_IMPORT_OVERRIDE,              CONST_CS | CONST_PERSISTENT);
-#endif
 
 	/* Feature Identifying constants */
 #ifdef PHP_RUNKIT_MANIPULATION
@@ -456,7 +439,7 @@ PHP_MINIT_FUNCTION(runkit)
 
 /* {{{ PHP_MSHUTDOWN_FUNCTION
  */
-PHP_MSHUTDOWN_FUNCTION(runkit)
+PHP_MSHUTDOWN_FUNCTION(runkit7)
 {
 #ifdef PHP_RUNKIT_MANIPULATION
 	pefree(RUNKIT_G(removed_function), 1);
@@ -551,7 +534,7 @@ static void php_runkit_rinit_register_superglobals(const char *ini_s)
 
 /* {{{ PHP_RINIT_FUNCTION
  */
-PHP_RINIT_FUNCTION(runkit)
+PHP_RINIT_FUNCTION(runkit7)
 {
 #ifdef PHP_RUNKIT_SUPERGLOBALS
 	php_runkit_rinit_register_superglobals(INI_STR("runkit.superglobal"));
@@ -586,7 +569,7 @@ static int php_runkit_superglobal_dtor(zval *zv)
 
 /* {{{ PHP_RSHUTDOWN_FUNCTION
  */
-PHP_RSHUTDOWN_FUNCTION(runkit)
+PHP_RSHUTDOWN_FUNCTION(runkit7)
 {
 	// #ifdef PHP_RUNKIT_MANIPULATION
 	// php_runkit_default_class_members_list_element *el;
@@ -659,15 +642,11 @@ PHP_RSHUTDOWN_FUNCTION(runkit)
 
 /* {{{ PHP_MINFO_FUNCTION
  */
-PHP_MINFO_FUNCTION(runkit)
+PHP_MINFO_FUNCTION(runkit7)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "runkit support", "enabled");
-	php_info_print_table_header(2, "version", PHP_RUNKIT_VERSION);
-
-#ifdef PHP_RUNKIT_CLASSKIT_COMPAT
-	php_info_print_table_header(2, "classkit compatibility", "enabled");
-#endif
+	php_info_print_table_header(2, "runkit7 support", "enabled");
+	php_info_print_table_header(2, "version", PHP_RUNKIT7_VERSION);
 
 #ifdef PHP_RUNKIT_SUPERGLOBALS
 	php_info_print_table_header(2, "Custom Superglobal support", "enabled");

--- a/runkit.h
+++ b/runkit.h
@@ -89,7 +89,7 @@ static inline void *_debug_emalloc(void *data, int bytes, char *file, int line)
 #define debug_printf(...) do { } while(0)
 #endif
 
-#define PHP_RUNKIT_VERSION					"2.1.0"
+#define PHP_RUNKIT7_VERSION					"3.0.0a1"
 #define PHP_RUNKIT_SANDBOX_CLASSNAME		"Runkit_Sandbox"
 #define PHP_RUNKIT_SANDBOX_PARENT_CLASSNAME	"Runkit_Sandbox_Parent"
 
@@ -103,8 +103,9 @@ static inline void *_debug_emalloc(void *data, int bytes, char *file, int line)
 #define PHP_RUNKIT_IMPORT_OVERRIDE            0x0020
 #define PHP_RUNKIT_OVERRIDE_OBJECTS           0x8000
 
-/* Hardcoded. TODO should not be. */
+#ifdef PHP_RUNKIT7_FEATURE_SUPER
 #define PHP_RUNKIT_SUPERGLOBALS
+#endif
 
 #ifdef PHP_RUNKIT_SPL_OBJECT_ID
 #if PHP_VERSION_ID < 70200
@@ -115,8 +116,8 @@ static inline void *_debug_emalloc(void *data, int bytes, char *file, int line)
 /* The TSRM interpreter patch required by runkit_sandbox was added in 5.1, but this package includes diffs for older versions
  * Those diffs include an additional #define to indicate that they've been applied
  */
-#ifdef PHP_RUNKIT_FEATURE_SANDBOX
-#if (defined ZTS) && (defined PHP_RUNKIT_FEATURE_SANDBOX)
+#ifdef PHP_RUNKIT7_FEATURE_SANDBOX
+#if (defined ZTS) && (defined PHP_RUNKIT7_FEATURE_SANDBOX)
 #define PHP_RUNKIT_SANDBOX
 #else
 // debugging code
@@ -124,7 +125,7 @@ static inline void *_debug_emalloc(void *data, int bytes, char *file, int line)
 #endif
 #endif
 
-#ifdef PHP_RUNKIT_FEATURE_MODIFY
+#ifdef PHP_RUNKIT7_FEATURE_MODIFY
 #define PHP_RUNKIT_MANIPULATION
 // TODO: Enable these macros once the corresponding functions/files compile and pass some of the tests.
 // TODO: Clean up these macros once the corresponding functions/files are 100% correct.
@@ -137,11 +138,11 @@ static inline void *_debug_emalloc(void *data, int bytes, char *file, int line)
 #include "Zend/zend_object_handlers.h"
 #endif
 
-PHP_MINIT_FUNCTION(runkit);
-PHP_MSHUTDOWN_FUNCTION(runkit);
-PHP_RINIT_FUNCTION(runkit);
-PHP_RSHUTDOWN_FUNCTION(runkit);
-PHP_MINFO_FUNCTION(runkit);
+PHP_MINIT_FUNCTION(runkit7);
+PHP_MSHUTDOWN_FUNCTION(runkit7);
+PHP_RINIT_FUNCTION(runkit7);
+PHP_RSHUTDOWN_FUNCTION(runkit7);
+PHP_MINFO_FUNCTION(runkit7);
 
 PHP_FUNCTION(runkit_object_id);
 #ifdef PHP_RUNKIT_PROVIDES_SPL_OBJECT_ID
@@ -204,7 +205,7 @@ typedef struct _php_runkit_sandbox_object php_runkit_sandbox_object;
 #endif
 
 #if defined(PHP_RUNKIT_SUPERGLOBALS) || defined(PHP_RUNKIT_SANDBOX) || defined(PHP_RUNKIT_MANIPULATION)
-ZEND_BEGIN_MODULE_GLOBALS(runkit)
+ZEND_BEGIN_MODULE_GLOBALS(runkit7)
 #ifdef PHP_RUNKIT_SUPERGLOBALS
 	HashTable *superglobals;
 #endif
@@ -220,15 +221,15 @@ ZEND_BEGIN_MODULE_GLOBALS(runkit)
 	zend_function *removed_function, *removed_method;
 	zend_bool module_moved_to_front;
 #endif
-ZEND_END_MODULE_GLOBALS(runkit)
+ZEND_END_MODULE_GLOBALS(runkit7)
 #endif
 
-extern ZEND_DECLARE_MODULE_GLOBALS(runkit)
+extern ZEND_DECLARE_MODULE_GLOBALS(runkit7)
 
 #ifdef ZTS
-#define		RUNKIT_G(v)		TSRMG(runkit_globals_id, zend_runkit_globals *, v)
+#define		RUNKIT_G(v)		TSRMG(runkit7_globals_id, zend_runkit7_globals *, v)
 #else
-#define		RUNKIT_G(v)		(runkit_globals.v)
+#define		RUNKIT_G(v)		(runkit7_globals.v)
 #endif
 
 #define RUNKIT_IS_CALLABLE(cb_zv, flags, cb_sp) zend_is_callable((cb_zv), (flags), (cb_sp))

--- a/tests/Runkit_Sandbox.allow_url_include.phpt
+++ b/tests/Runkit_Sandbox.allow_url_include.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox - Allow disabling of allow_url_include
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; ?>
 --INI--
 allow_url_include="On"
 --FILE--

--- a/tests/Runkit_Sandbox.open_basedir.phpt
+++ b/tests/Runkit_Sandbox.open_basedir.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox - Prevent overriding open_basedir when a bogus path is present
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; ?>
 --INI--
 open_basedir="/bogus-does-not-exist-runkit-test-dir"
 --FILE--

--- a/tests/Runkit_Sandbox_.active.phpt
+++ b/tests/Runkit_Sandbox_.active.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox['active'] status
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip";
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_.output_handler.phpt
+++ b/tests/Runkit_Sandbox_.output_handler.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox['output_handler'] setting
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent1.phpt
+++ b/tests/Runkit_Sandbox_Parent1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Instantiation from outter scope
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent2.phpt
+++ b/tests/Runkit_Sandbox_Parent2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Locked Access
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.call.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.call.access.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Locked Call
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.call.phpt
+++ b/tests/Runkit_Sandbox_Parent__.call.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Call
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.die.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.die.access.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Locked Patricide
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.die.phpt
+++ b/tests/Runkit_Sandbox_Parent__.die.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Patricide
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.echo.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.echo.access.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Echo
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.echo.phpt
+++ b/tests/Runkit_Sandbox_Parent__.echo.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Echo
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.eval.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.eval.access.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Locked Eval
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.eval.phpt
+++ b/tests/Runkit_Sandbox_Parent__.eval.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Eval
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip";
 	  /* May not be available due to lack of TSRM interpreter support */
 	  if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.read.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.read.access.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Locked Read Access
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.read.phpt
+++ b/tests/Runkit_Sandbox_Parent__.read.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Read Access
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.scope.phpt
+++ b/tests/Runkit_Sandbox_Parent__.scope.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Scopes
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.write.access.phpt
+++ b/tests/Runkit_Sandbox_Parent__.write.access.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Locked Write Access
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox_Parent__.write.phpt
+++ b/tests/Runkit_Sandbox_Parent__.write.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox_Parent Class -- Write Access
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__call.phpt
+++ b/tests/Runkit_Sandbox__call.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox::__call() method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__call_user_func_closure.phpt
+++ b/tests/Runkit_Sandbox__call_user_func_closure.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox::__call_user_func() method with closure as the first parameter
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip";
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip";
       if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";

--- a/tests/Runkit_Sandbox__die.phpt
+++ b/tests/Runkit_Sandbox__die.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox::die() method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__disable_classes.phpt
+++ b/tests/Runkit_Sandbox__disable_classes.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox() - disable_classes test
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip";
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__disable_functions.phpt
+++ b/tests/Runkit_Sandbox__disable_functions.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox() - disable_functions test
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__echo.phpt
+++ b/tests/Runkit_Sandbox__echo.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox::echo() method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__eval.phpt
+++ b/tests/Runkit_Sandbox__eval.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox::eval() method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__get.phpt
+++ b/tests/Runkit_Sandbox__get.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox::__get() method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__grandchild.phpt
+++ b/tests/Runkit_Sandbox__grandchild.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox Nesting
 --SKIPIF--
-<?php if(!extension_loaded("runkit")) print "skip"; 
+<?php if(!extension_loaded("runkit7")) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/Runkit_Sandbox__set.phpt
+++ b/tests/Runkit_Sandbox__set.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Runkit_Sandbox::__set() method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip"; ?>
 --FILE--

--- a/tests/bug10053.phpt
+++ b/tests/bug10053.phpt
@@ -2,7 +2,7 @@
 runkit_method_copy() function
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/bug10300.phpt
+++ b/tests/bug10300.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #10300 Segfault when copying __call()
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 error_reporting=E_ALL
 display_errors=on

--- a/tests/bug4519.phpt
+++ b/tests/bug4519.phpt
@@ -2,7 +2,7 @@
 Bug #4519 Unable to override class definitions of a derived class
 --SKIPIF--
 <?php
-if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
+if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
 elseif (PHP_VERSION_ID >= 70300) print "skip TODO Fix https://github.com/runkit7/runkit7/issues/135";
 ?>
 --FILE--

--- a/tests/bug56662.phpt
+++ b/tests/bug56662.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug#56662 - Wrong access level with RUNKIT_ACC_PUBLIC
 --SKIPIF--
-<?php if(!extension_loaded("runkit")) print "skip"; ?>
+<?php if(!extension_loaded("runkit7")) print "skip"; ?>
 --FILE--
 <?php
 class A {}

--- a/tests/bug56976.phpt
+++ b/tests/bug56976.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug#56976 - Failure adding __call method
 --SKIPIF--
-<?php if(!extension_loaded("runkit")) print "skip"; ?>
+<?php if(!extension_loaded("runkit7")) print "skip"; ?>
 --FILE--
 <?php
 class ParentClass

--- a/tests/bug57249.phpt
+++ b/tests/bug57249.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug#57249 - Shutdown bug with runkit_import on a function-static variable
 --SKIPIF--
-<?php if (!extension_loaded("runkit") || !function_exists('runkit_import')) print "skip"; ?>
+<?php if (!extension_loaded("runkit7") || !function_exists('runkit_import')) print "skip"; ?>
 --FILE--
 <?php
 runkit_import('bug57249.inc', RUNKIT_IMPORT_CLASS_METHODS);

--- a/tests/bug57649.phpt
+++ b/tests/bug57649.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug#57649 - runkit_import() - methods not added - multiple classes in one file
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !function_exists('runkit_import')) print "skip";
+<?php if(!extension_loaded("runkit7") || !function_exists('runkit_import')) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/bug57658.phpt
+++ b/tests/bug57658.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug#57658 - runkit_class_adopt fails on method names with capitals
 --SKIPIF--
-<?php if (!extension_loaded("runkit") || !function_exists('runkit_class_adopt')) print "skip"; ?>
+<?php if (!extension_loaded("runkit7") || !function_exists('runkit_class_adopt')) print "skip"; ?>
 --FILE--
 <?php
 error_reporting(E_ALL & ~E_STRICT);

--- a/tests/bug64496.phpt
+++ b/tests/bug64496.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug #64496 - Runkit_Sandbox override of open_basedir when parent uses multiple paths
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip";
       if(version_compare(PHP_VERSION, '5.3.0', '<')) print "skip";
 ?>
 --FILE--

--- a/tests/namespaces.phpt
+++ b/tests/namespaces.phpt
@@ -2,7 +2,7 @@
 runkit_method_add(), runkit_method_redefine(), runkit_method_rename() & runkit_method_copy() functions with namespaces
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_add_magic_methods.phpt
+++ b/tests/runkit_add_magic_methods.phpt
@@ -1,7 +1,7 @@
 --TEST--
 adding and removing magic methods
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_add_magic_serialize_method_ignored_for_common_classes.phpt
+++ b/tests/runkit_add_magic_serialize_method_ignored_for_common_classes.phpt
@@ -1,7 +1,7 @@
 --TEST--
 adding magic serialize method to common class should be ignored
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_add_old_style_ctor.phpt
+++ b/tests/runkit_add_old_style_ctor.phpt
@@ -1,7 +1,7 @@
 --TEST--
 add old-style parent ctor
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_add_old_style_ctor1.phpt
+++ b/tests/runkit_add_old_style_ctor1.phpt
@@ -1,7 +1,7 @@
 --TEST--
 add old-style parent ctor (existing ctor)
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_add_old_style_ctor_by_adopting.phpt
+++ b/tests/runkit_add_old_style_ctor_by_adopting.phpt
@@ -1,7 +1,7 @@
 --TEST--
 add old-style parent ctor by adoptting
 --SKIPIF--
-<?php if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
+<?php if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_add_old_style_ctor_by_copying.phpt
+++ b/tests/runkit_add_old_style_ctor_by_copying.phpt
@@ -1,7 +1,7 @@
 --TEST--
 add old-style parent ctor by copying
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_add_old_style_ctor_by_importing.phpt
+++ b/tests/runkit_add_old_style_ctor_by_importing.phpt
@@ -1,7 +1,7 @@
 --TEST--
 add old-style parent ctor by importing
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_adopt_emancipate_and_inheritance.phpt
+++ b/tests/runkit_adopt_emancipate_and_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_class_adopt, runkit_class_emancipate and inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
 --FILE--
 <?php
 class myParent {}

--- a/tests/runkit_and_superglobals.phpt
+++ b/tests/runkit_and_superglobals.phpt
@@ -2,7 +2,7 @@
 Superglobals should not be wiped by runkit
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_arginfo.phpt
+++ b/tests/runkit_arginfo.phpt
@@ -2,7 +2,7 @@
 reflection should pick up runkit7 arginfo
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !function_exists('runkit_superglobals') || !PHP_RUNKIT_MANIPULATION) print "skip";
+if(!extension_loaded("runkit7") || !function_exists('runkit_superglobals') || !PHP_RUNKIT_MANIPULATION) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_class_adopt.phpt
+++ b/tests/runkit_class_adopt.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_class_adopt() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
 --FILE--
 <?php
 class Grandparent {

--- a/tests/runkit_class_adopt_and_properties.phpt
+++ b/tests/runkit_class_adopt_and_properties.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_class_adopt() function and properties issues
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_adopt')) print "skip"; ?>
 --FILE--
 <?php
 class C {

--- a/tests/runkit_class_emancipate.phpt
+++ b/tests/runkit_class_emancipate.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_class_emancipate() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_emancipate')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_emancipate')) print "skip"; ?>
 --FILE--
 <?php
 class Grandparent {

--- a/tests/runkit_class_emancipate_and_reflection.phpt
+++ b/tests/runkit_class_emancipate_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_class_emancipate() function with reflection and inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_emancipate')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_class_emancipate')) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {
@@ -43,4 +43,4 @@ object(ReflectionMethod)#%d (2) {
   string(11) "RunkitClass"
 }
 
-Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit was somehow invoked in %s on line %d
+Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_constant_add.phpt
+++ b/tests/runkit_constant_add.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_constant_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 runkit_constant_add('FOO', "BAR\n");

--- a/tests/runkit_constant_add_array.phpt
+++ b/tests/runkit_constant_add_array.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_constant_add() function can add simple arrays
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 runkit_constant_add('FOO', ["BAR"]);

--- a/tests/runkit_constant_add_array_7.phpt
+++ b/tests/runkit_constant_add_array_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_constant_add() function can add simple arrays
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 runkit7_constant_add('FOO', ["BAR"]);

--- a/tests/runkit_constant_add_array_to_class.phpt
+++ b/tests/runkit_constant_add_array_to_class.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_constant_add() function can add simple arrays to classes
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class A { }

--- a/tests/runkit_constant_add_protected.phpt
+++ b/tests/runkit_constant_add_protected.phpt
@@ -2,7 +2,7 @@
 runkit_constant_redefine() function redefines protected class constants (when accessing other files, not working for same file)
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_add_protected_7.phpt
+++ b/tests/runkit_constant_add_protected_7.phpt
@@ -2,7 +2,7 @@
 runkit7_constant_redefine() function redefines protected class constants (when accessing other files, not working for same file)
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip";
+if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_add_to_class.phpt
+++ b/tests/runkit_constant_add_to_class.phpt
@@ -2,7 +2,7 @@
 runkit_constant_add() function redefines class constants
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_redefine.phpt
+++ b/tests/runkit_constant_redefine.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_constant_redefine() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 define('FOO', "The FOO constant\n");

--- a/tests/runkit_constant_redefine_in_class.phpt
+++ b/tests/runkit_constant_redefine_in_class.phpt
@@ -2,7 +2,7 @@
 runkit_constant_redefine() function redefines class constants
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_redefine_protected_across_file.phpt
+++ b/tests/runkit_constant_redefine_protected_across_file.phpt
@@ -2,7 +2,7 @@
 runkit_constant_redefine() function redefines protected class constants (when accessing other files, not working for same file)
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_remove.phpt
+++ b/tests/runkit_constant_remove.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_constant_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 define('FOO', "BAR\n");

--- a/tests/runkit_constant_remove_from_class.phpt
+++ b/tests/runkit_constant_remove_from_class.phpt
@@ -2,7 +2,7 @@
 runkit_constant_remove() function removes constant from class
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_remove_from_class_without_inlining.phpt
+++ b/tests/runkit_constant_remove_from_class_without_inlining.phpt
@@ -4,7 +4,7 @@ runkit_constant_remove() function removes constant from class (Easier to do: no 
 x=1
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constant_remove_from_ns.phpt
+++ b/tests/runkit_constant_remove_from_ns.phpt
@@ -2,7 +2,7 @@
 runkit_constant_remove(), runkit_constant_add(), and namespaces
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_constants_manipulations_and_cache.phpt
+++ b/tests/runkit_constants_manipulations_and_cache.phpt
@@ -2,7 +2,7 @@
 Test for caching issues on manipulations with constants
 --SKIPIF--
 <?php
-  if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+  if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_default_property_add.phpt
+++ b/tests/runkit_default_property_add.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties.phpt
+++ b/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() and runkit_default_property_remove() functions on classes having dynamic properties
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties_overriding_in_objects.phpt
+++ b/tests/runkit_default_property_add_and_remove_for_class_with_dynamic_properties_overriding_in_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() and runkit_default_property_remove() functions on classes having dynamic properties overriding in objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_add_instance.phpt
+++ b/tests/runkit_default_property_add_instance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() function - instance override
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_overriding_objects.phpt
+++ b/tests/runkit_default_property_add_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() function with overriding objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_to_subclasses.phpt
+++ b/tests/runkit_default_property_add_to_subclasses.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() add properties to subclasses
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_add_to_subclasses_overriding_objects.phpt
+++ b/tests/runkit_default_property_add_to_subclasses_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() add properties to subclasses overriding objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove.phpt
+++ b/tests/runkit_default_property_remove.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties.phpt
+++ b/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() and runkit_default_property_add() functions on classes having dynamic properties (without overriding objects)
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_and_add_for_class_with_dynamic_properties_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() and runkit_default_property_add() functions on classes having dynamic properties (overriding objects)
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_remove_and_reflection.phpt
+++ b/tests/runkit_default_property_remove_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_remove() function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_default_property_remove_from_subclasses.phpt
+++ b/tests/runkit_default_property_remove_from_subclasses.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove properties from subclasses
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_from_subclasses_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_from_subclasses_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove properties from subclasses overriding objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_inheritance.phpt
+++ b/tests/runkit_default_property_remove_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove properties with inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_inheritance_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_inheritance_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove properties with inheritance overriding objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() function overriding objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_and_inheritance.phpt
+++ b/tests/runkit_default_property_remove_private_and_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove private properties with inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_and_inheritance_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_private_and_inheritance_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove private properties with inheritance overriding objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_shadow_and_inheritance.phpt
+++ b/tests/runkit_default_property_remove_private_shadow_and_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove private properties with inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_shadow_and_inheritance54.phpt
+++ b/tests/runkit_default_property_remove_private_shadow_and_inheritance54.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove private properties with inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_private_shadow_and_inheritance_overriding_objects.phpt
+++ b/tests/runkit_default_property_remove_private_shadow_and_inheritance_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() remove private properties with inheritance with objects overriding
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_default_property_remove_simple.phpt
+++ b/tests/runkit_default_property_remove_simple.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_remove')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_finally.phpt
+++ b/tests/runkit_finally.phpt
@@ -2,7 +2,7 @@
 copy method with finally
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_fpm_internal_function_restore.phpt
+++ b/tests/runkit_fpm_internal_function_restore.phpt
@@ -16,7 +16,7 @@ echo _chop('A B '), "\n";
 echo __chop('C D '), "\n";
 echo "Test End\n";
 EOT;
-fpm_test(array($code, $code, $code), "-n -d extension_dir=modules/ -d extension=runkit.so -d runkit.internal_override=1");
+fpm_test(array($code, $code, $code), "-n -d extension_dir=modules/ -d extension=runkit7.so -d runkit.internal_override=1");
 ?>
 Done
 --EXPECTF--

--- a/tests/runkit_function_add.phpt
+++ b/tests/runkit_function_add.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 $name = 'runkitSample';

--- a/tests/runkit_function_add_7.phpt
+++ b/tests/runkit_function_add_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_function_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 $name = 'runkitSample';

--- a/tests/runkit_function_add_and_doc_comment.phpt
+++ b/tests/runkit_function_add_and_doc_comment.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_add() function and doc_comment
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_function_add_closure.phpt
+++ b/tests/runkit_function_add_closure.phpt
@@ -2,7 +2,7 @@
 runkit_method_add() function with closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_add_closure_and_doc_comment.phpt
+++ b/tests/runkit_function_add_closure_and_doc_comment.phpt
@@ -2,7 +2,7 @@
 runkit_function_add() closure and doc_comment
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_add_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_function_add_closure_and_doc_comment_from_closure.phpt
@@ -2,7 +2,7 @@
 runkit_function_add() closer and doc_comment from closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_add_return_type.phpt
+++ b/tests/runkit_function_add_return_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_add() function should accept valid return types passed in as a string
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_function_add_return_type_invalid.phpt
+++ b/tests/runkit_function_add_return_type_invalid.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_add() function should detect invalid return types passed in as a string
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_function_copy.phpt
+++ b/tests/runkit_function_copy.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_copy() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitSample($n) {

--- a/tests/runkit_function_copy_7.phpt
+++ b/tests/runkit_function_copy_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_function_copy() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitSample($n) {

--- a/tests/runkit_function_redefine.phpt
+++ b/tests/runkit_function_redefine.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 $a = 'a';

--- a/tests/runkit_function_redefine_7.phpt
+++ b/tests/runkit_function_redefine_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_function_redefine() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 $a = 'a';

--- a/tests/runkit_function_redefine_and_doc_comment.phpt
+++ b/tests/runkit_function_redefine_and_doc_comment.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() function and doc_comment
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_function_redefine_and_reflection.phpt
+++ b/tests/runkit_function_redefine_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitFunction($param) {
@@ -21,4 +21,4 @@ object(ReflectionFunction)#%d (1) {
   string(30) "__function_removed_by_runkit__"
 }
 
-Fatal error: __function_removed_by_runkit__(): A function removed by runkit was somehow invoked in %s on line %d
+Fatal error: __function_removed_by_runkit__(): A function removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_function_redefine_and_revert.phpt
+++ b/tests/runkit_function_redefine_and_revert.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() and revert
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 error_reporting=E_ALL
 display_errors=on

--- a/tests/runkit_function_redefine_closure.phpt
+++ b/tests/runkit_function_redefine_closure.phpt
@@ -2,7 +2,7 @@
 runkit_method_redefine() function with closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	if(version_compare(PHP_VERSION, '7.1.0', '>=')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_function_redefine_closure_and_doc_comment.phpt
+++ b/tests/runkit_function_redefine_closure_and_doc_comment.phpt
@@ -2,7 +2,7 @@
 runkit_function_redefine() closure and doc_comment
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_redefine_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_function_redefine_closure_and_doc_comment_from_closure.phpt
@@ -2,7 +2,7 @@
 runkit_function_redefine() closure and doc_comment from closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_redefine_closure_static.phpt
+++ b/tests/runkit_function_redefine_closure_static.phpt
@@ -2,7 +2,7 @@
 runkit_method_redefine() function with closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_redefine_from_anonymous.phpt
+++ b/tests/runkit_function_redefine_from_anonymous.phpt
@@ -2,7 +2,7 @@
 runkit_function_redefine() and call from anonymous function
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_function_redefine_using_undef.phpt
+++ b/tests/runkit_function_redefine_using_undef.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() function with undefined 
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_function_redefine_var_dump.phpt
+++ b/tests/runkit_function_redefine_var_dump.phpt
@@ -2,7 +2,7 @@
 runkit_method_redefine() function with closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_function_remove.phpt
+++ b/tests/runkit_function_remove.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitSample() {

--- a/tests/runkit_function_remove_7.phpt
+++ b/tests/runkit_function_remove_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_function_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitSample() {

--- a/tests/runkit_function_remove_and_reflection.phpt
+++ b/tests/runkit_function_remove_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_remove() function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitFunction($param) {
@@ -21,4 +21,4 @@ object(ReflectionFunction)#%d (1) {
   string(30) "__function_removed_by_runkit__"
 }
 
-Fatal error: __function_removed_by_runkit__(): A function removed by runkit was somehow invoked in %s on line %d
+Fatal error: __function_removed_by_runkit__(): A function removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_function_remove_and_reflection_parameter.phpt
+++ b/tests/runkit_function_remove_and_reflection_parameter.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_remove() function with ReflectionParameter
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitFunction($param) {

--- a/tests/runkit_function_rename.phpt
+++ b/tests/runkit_function_rename.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_rename() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitSample($n) {

--- a/tests/runkit_function_rename_7.phpt
+++ b/tests/runkit_function_rename_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_function_rename() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitSample($n) {

--- a/tests/runkit_function_rename_and_reflection.phpt
+++ b/tests/runkit_function_rename_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_rename() function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function runkitFunction($param) {
@@ -21,4 +21,4 @@ object(ReflectionFunction)#%d (1) {
   string(30) "__function_removed_by_runkit__"
 }
 
-Fatal error: __function_removed_by_runkit__(): A function removed by runkit was somehow invoked in %s on line %d
+Fatal error: __function_removed_by_runkit__(): A function removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_function_rename_corruption.phpt
+++ b/tests/runkit_function_rename_corruption.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_rename() function corruption prevented when original method is replaced with a substitute.
 --SKIPIF--
-<?php if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_function_rename_corruption2.phpt
+++ b/tests/runkit_function_rename_corruption2.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_rename() function corruption prevented when original method is replaced with a substitute.
 --SKIPIF--
-<?php if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_function_rename_internal.phpt
+++ b/tests/runkit_function_rename_internal.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_rename() function on internal functions
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 runkit.internal_override=On
 --FILE--

--- a/tests/runkit_function_rename_large_switch.phpt
+++ b/tests/runkit_function_rename_large_switch.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_rename() function with large switch statements
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 // See https://derickrethans.nl/php7.2-switch.html for an explanation of this optimization.

--- a/tests/runkit_function_rename_redefine_add_remove.phpt
+++ b/tests/runkit_function_rename_redefine_add_remove.phpt
@@ -1,7 +1,7 @@
 --TEST--
 complex test for renaming, adding and removing with internal functions
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 error_reporting=E_ALL
 display_errors=on

--- a/tests/runkit_function_variadic.phpt
+++ b/tests/runkit_function_variadic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() function and runkit_function_remove(), with variadic functions
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_function_variadic_strict.phpt
+++ b/tests/runkit_function_variadic_strict.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() function and runkit_function_remove(), with variadic functions and strict mode.
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_function_variadic_typed.phpt
+++ b/tests/runkit_function_variadic_typed.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() function, etc. can redefine variadic functions with return types.
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_functions_redefining_and_cache.phpt
+++ b/tests/runkit_functions_redefining_and_cache.phpt
@@ -2,7 +2,7 @@
 Test for caching issues on redefining functions
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
+if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_functions_returning_by_reference.phpt
+++ b/tests/runkit_functions_returning_by_reference.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_function_redefine() & runkit_function_add() for functions returning a value by reference
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT) & (~E_NOTICE));

--- a/tests/runkit_import_class.phpt
+++ b/tests/runkit_import_class.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing and overriding classes
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 if (!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_class_extend.phpt
+++ b/tests/runkit_import_class_extend.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing and overriding classes extending another loaded class
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 if (!function_exists('runkit_import')) print "skip";
 if ((DIRECTORY_SEPARATOR === "\\" && !ZEND_THREAD_SAFE) || PHP_VERSION_ID >= 70300) {
 	print "skip this is a known bug on windows/PHP 7.3 and only affects NTS runkit_import(). https://github.com/runkit7/runkit7/issues/135 was filed to investigate this\n";

--- a/tests/runkit_import_class_property.phpt
+++ b/tests/runkit_import_class_property.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing and overriding class properties
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_class_property_and_inheritance.phpt
+++ b/tests/runkit_import_class_property_and_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing and overriding class properties with inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_class_property_and_inheritance_overriding_objects.phpt
+++ b/tests/runkit_import_class_property_and_inheritance_overriding_objects.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing and overriding class properties with inheritance with overriding objects
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_class_property_not_overriding_subclasses.phpt
+++ b/tests/runkit_import_class_property_not_overriding_subclasses.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing and not overriding subclass properties
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_constant_properties.phpt
+++ b/tests/runkit_import_constant_properties.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding property with constant array as the value
 --SKIPIF--
 <?php
-    if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+    if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
     if(!function_exists('runkit_import')) print "skip"
 ?>
 --FILE--

--- a/tests/runkit_import_constant_static_properties.phpt
+++ b/tests/runkit_import_constant_static_properties.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding static property with constant array as the value
 --SKIPIF--
 <?php
-    if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+    if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
     if(!function_exists('runkit_import')) print "skip"
 ?>
 --FILE--

--- a/tests/runkit_import_constants_and_inheritance.phpt
+++ b/tests/runkit_import_constants_and_inheritance.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding constants with inheritance
 --SKIPIF--
 <?php
-    if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+    if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
     if(!function_exists('runkit_import')) print "skip"
 ?>
 --FILE--

--- a/tests/runkit_import_function_and_reflection.phpt
+++ b/tests/runkit_import_function_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() imports function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
 --FILE--
 <?php
 function runkitFunction($param) {
@@ -21,4 +21,4 @@ object(ReflectionFunction)#%d (1) {
   string(30) "__function_removed_by_runkit__"
 }
 
-Fatal error: __function_removed_by_runkit__(): A function removed by runkit was somehow invoked in %s on line %d
+Fatal error: __function_removed_by_runkit__(): A function removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_import_function_with_static_var.phpt
+++ b/tests/runkit_import_function_with_static_var.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding function with a static variable
 --SKIPIF--
 <?php
-    if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
+    if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_import_functions.phpt
+++ b/tests/runkit_import_functions.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing and overriding functions
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_import_method_and_reflection.phpt
+++ b/tests/runkit_import_method_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() method and reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {
@@ -29,4 +29,4 @@ object(ReflectionMethod)#%d (2) {
   string(11) "RunkitClass"
 }
 
-Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit was somehow invoked in %s on line %d
+Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_import_method_with_closure.phpt
+++ b/tests/runkit_import_method_with_closure.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding method with closure
 --SKIPIF--
 <?php
-    if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+    if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
     if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_method_with_static_var.phpt
+++ b/tests/runkit_import_method_with_static_var.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding method with a static variable
 --SKIPIF--
 <?php
-    if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
+    if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_import_methods.phpt
+++ b/tests/runkit_import_methods.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding class methods
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !function_exists('runkit_import')) print "skip";
+if(!extension_loaded("runkit7") || !function_exists('runkit_import')) print "skip";
 if ((DIRECTORY_SEPARATOR === "\\" && !ZEND_THREAD_SAFE) || PHP_VERSION_ID >= 70300) {
 	print "skip TODO: Fix PHP 7.3 NTS runkit_import(). https://github.com/runkit7/runkit7/issues/135 was filed to investigate this\n";
 }

--- a/tests/runkit_import_methods_7.phpt
+++ b/tests/runkit_import_methods_7.phpt
@@ -2,7 +2,7 @@
 runkit7_import() Importing and overriding class methods
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit") || !function_exists('runkit7_import')) print "skip";
+if(!extension_loaded("runkit7") || !function_exists('runkit7_import')) print "skip";
 if ((DIRECTORY_SEPARATOR === "\\" && !ZEND_THREAD_SAFE) || PHP_VERSION_ID >= 70300) {
 	print "skip TODO: Fix PHP 7.3 NTS runkit7_import(). https://github.com/runkit7/runkit7/issues/135 was filed to investigate this\n";
 }

--- a/tests/runkit_import_non_existent_file.phpt
+++ b/tests/runkit_import_non_existent_file.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing non-existent file
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_properties_modified_via_reflection.phpt
+++ b/tests/runkit_import_properties_modified_via_reflection.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding properties which were modified via reflection
 --SKIPIF--
 <?php
-    if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+    if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
     if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_import_static_properties_override.phpt
+++ b/tests/runkit_import_static_properties_override.phpt
@@ -2,7 +2,7 @@
 runkit_import() Importing and overriding non-static and static properties with static properties
 --SKIPIF--
 <?php
-	if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) {
+	if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) {
 		echo "skip";
 	}
 	if (!function_exists('runkit_import')) {

--- a/tests/runkit_import_with_syntax_error.phpt
+++ b/tests/runkit_import_with_syntax_error.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_import() Importing file with syntax error in it
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_import')) print "skip";
 ?>
 --FILE--

--- a/tests/runkit_lint.phpt
+++ b/tests/runkit_lint.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_lint() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip";
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_lint")) print "skip";
       /* Note: It's not currently possible to change the value of html_errors in a subinterpreter from SYSTEM settings.... */

--- a/tests/runkit_method_add.phpt
+++ b/tests/runkit_method_add.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_add_7.phpt
+++ b/tests/runkit_method_add_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_method_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_add_and_doc_comment.phpt
+++ b/tests/runkit_method_add_and_doc_comment.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_add() function and doc_comment
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_add_closure.phpt
+++ b/tests/runkit_method_add_closure.phpt
@@ -2,7 +2,7 @@
 runkit_method_add() function with closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_closure2.phpt
+++ b/tests/runkit_method_add_closure2.phpt
@@ -2,7 +2,7 @@
 runkit_method_add() function with closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_closure_and_doc_comment.phpt
+++ b/tests/runkit_method_add_closure_and_doc_comment.phpt
@@ -2,7 +2,7 @@
 runkit_method_add() function with closure and doc_comment
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_method_add_closure_and_doc_comment_from_closure.phpt
@@ -2,7 +2,7 @@
 runkit_method_add() function with closure and doc_comment from closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_closure_and_flags.phpt
+++ b/tests/runkit_method_add_closure_and_flags.phpt
@@ -2,7 +2,7 @@
 runkit_method_add() function with closure and flags
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_add_overriding_parent_method.phpt
+++ b/tests/runkit_method_add_overriding_parent_method.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_add() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_add_php73_bug.phpt
+++ b/tests/runkit_method_add_php73_bug.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Bug in runkit_method_add (runkit7 issue #173)
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_add_return_type.phpt
+++ b/tests/runkit_method_add_return_type.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_add() function should accept valid return types passed in as a string
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_add_return_type_invalid.phpt
+++ b/tests/runkit_method_add_return_type_invalid.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_add() function should detect invalid return types passed in as a string
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_copy.phpt
+++ b/tests/runkit_method_copy.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_copy() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_copy_7.phpt
+++ b/tests/runkit_method_copy_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_method_copy() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_copy_and_doc_comment.phpt
+++ b/tests/runkit_method_copy_and_doc_comment.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_copy() function and doc_comment
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_copy_and_doc_comment_leak.phpt
+++ b/tests/runkit_method_copy_and_doc_comment_leak.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_copy() function and doc_comment - test if one call to copy will leak memory
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_copy_uninit_read.phpt
+++ b/tests/runkit_method_copy_uninit_read.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_copy() causes uninitialized read
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_method_redefine.phpt
+++ b/tests/runkit_method_redefine.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_redefine_7.phpt
+++ b/tests/runkit_method_redefine_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_method_redefine() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_redefine_and_doc_comment.phpt
+++ b/tests/runkit_method_redefine_and_doc_comment.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function and doc_comment
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_redefine_and_reflection.phpt
+++ b/tests/runkit_method_redefine_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {
@@ -29,4 +29,4 @@ object(ReflectionMethod)#%d (2) {
   string(11) "RunkitClass"
 }
 
-Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit was somehow invoked in %s on line %d
+Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_method_redefine_and_reflection_with_inheritance.phpt
+++ b/tests/runkit_method_redefine_and_reflection_with_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function with reflection and inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {
@@ -30,4 +30,4 @@ object(ReflectionMethod)#%d (2) {
   string(11) "RunkitClass"
 }
 
-Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit was somehow invoked in %s on line %d
+Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_method_redefine_closure_and_doc_comment.phpt
+++ b/tests/runkit_method_redefine_closure_and_doc_comment.phpt
@@ -2,7 +2,7 @@
 runkit_method_redefine() function with closure and doc_comment
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_redefine_closure_and_doc_comment_from_closure.phpt
+++ b/tests/runkit_method_redefine_closure_and_doc_comment_from_closure.phpt
@@ -2,7 +2,7 @@
 runkit_method_redefine() function with closure and doc_comment from closure
 --SKIPIF--
 <?php
-	if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+	if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --INI--
 display_errors=on

--- a/tests/runkit_method_redefine_protected.phpt
+++ b/tests/runkit_method_redefine_protected.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function for protected methods
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 error_reporting=E_ALL
 display_errors=on

--- a/tests/runkit_method_redefine_update_proto.phpt
+++ b/tests/runkit_method_redefine_update_proto.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() must also update children methods' prototypes
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_method_redefine_with_static_vars.phpt
+++ b/tests/runkit_method_redefine_with_static_vars.phpt
@@ -1,7 +1,7 @@
 --TEST--
 redefining methods with static variables
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_remove.phpt
+++ b/tests/runkit_method_remove.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_remove_7.phpt
+++ b/tests/runkit_method_remove_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_method_remove() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_remove_and_reflection.phpt
+++ b/tests/runkit_method_remove_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_remove() function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {
@@ -40,4 +40,4 @@ object(ReflectionMethod)#%d (2) {
   string(11) "RunkitClass"
 }
 
-Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit was somehow invoked in %s on line %d
+Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_method_remove_and_reflection_parameter.phpt
+++ b/tests/runkit_method_remove_and_reflection_parameter.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_remove() function with ReflectionParameter
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {

--- a/tests/runkit_method_remove_and_reflection_parameter_with_inheritance.phpt
+++ b/tests/runkit_method_remove_and_reflection_parameter_with_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_remove() function with ReflectionParameter and inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {

--- a/tests/runkit_method_remove_and_reflection_with_inheritance.phpt
+++ b/tests/runkit_method_remove_and_reflection_with_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_remove() function with reflection and inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {
@@ -41,4 +41,4 @@ object(ReflectionMethod)#%d (2) {
   string(11) "RunkitClass"
 }
 
-Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit was somehow invoked in %s on line %d
+Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_method_rename.phpt
+++ b/tests/runkit_method_rename.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_rename() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_rename_002.phpt
+++ b/tests/runkit_method_rename_002.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Rename children of ancestor methods
 --SKIPIF--
-<?php if(!extension_loaded("runkit")) print "skip"; ?>
+<?php if(!extension_loaded("runkit7")) print "skip"; ?>
 --FILE--
 <?php
 function getClassMethods($class)

--- a/tests/runkit_method_rename_7.phpt
+++ b/tests/runkit_method_rename_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_method_rename() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_rename_and_access.phpt
+++ b/tests/runkit_method_rename_and_access.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_rename() function should set method's scope correctly
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_rename_and_reflection.phpt
+++ b/tests/runkit_method_rename_and_reflection.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_rename() function with reflection
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 class RunkitClass {
@@ -40,4 +40,4 @@ object(ReflectionMethod)#%d (2) {
   string(11) "RunkitClass"
 }
 
-Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit was somehow invoked in %s on line %d
+Fatal error: RunkitClass::__method_removed_by_runkit__(): A method removed by runkit7 was somehow invoked in %s on line %d

--- a/tests/runkit_method_rename_inheritance.phpt
+++ b/tests/runkit_method_rename_inheritance.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_rename() function and inheritance
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_rename_repeated.phpt
+++ b/tests/runkit_method_rename_repeated.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_rename() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_variadic.phpt
+++ b/tests/runkit_method_variadic.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function and runkit_method_remove(), with variadic functions
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_variadic_strict.phpt
+++ b/tests/runkit_method_variadic_strict.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function and runkit_method_remove(), with variadic functions and strict mode.
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_method_variadic_typed.phpt
+++ b/tests/runkit_method_variadic_typed.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() function and runkit_method_remove(), with variadic functions with return values
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 --FILE--

--- a/tests/runkit_methods_redefining_and_cache.phpt
+++ b/tests/runkit_methods_redefining_and_cache.phpt
@@ -2,7 +2,7 @@
 Test for caching issues on redefining class methods
 --SKIPIF--
 <?php
-if (!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
+if (!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('runkit_import')) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_methods_returning_by_reference.phpt
+++ b/tests/runkit_methods_returning_by_reference.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_method_redefine() & runkit_method_add() for methods returning a value by reference
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 ini_set('error_reporting', E_ALL & (~E_DEPRECATED) & (~E_STRICT) & (~E_NOTICE));

--- a/tests/runkit_object_id.phpt
+++ b/tests/runkit_object_id.phpt
@@ -2,7 +2,7 @@
 runkit_object_id should fetch the object handle.
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit")) print "skip";
+if(!extension_loaded("runkit7")) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_object_id_7.phpt
+++ b/tests/runkit_object_id_7.phpt
@@ -2,7 +2,7 @@
 runkit7_object_id should fetch the object handle.
 --SKIPIF--
 <?php
-if(!extension_loaded("runkit")) print "skip";
+if(!extension_loaded("runkit7")) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_redefine_old_style_ctor.phpt
+++ b/tests/runkit_redefine_old_style_ctor.phpt
@@ -1,7 +1,7 @@
 --TEST--
 redefine old-style parent ctor
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 

--- a/tests/runkit_remove_magic_call_method.phpt
+++ b/tests/runkit_remove_magic_call_method.phpt
@@ -1,7 +1,7 @@
 --TEST--
 removing magic __call method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_callstatic_method.phpt
+++ b/tests/runkit_remove_magic_callstatic_method.phpt
@@ -1,7 +1,7 @@
 --TEST--
 removing magic __callstatic method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_serialize_method.phpt
+++ b/tests/runkit_remove_magic_serialize_method.phpt
@@ -1,7 +1,7 @@
 --TEST--
 removing magic serialize method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_tostring_method.phpt
+++ b/tests/runkit_remove_magic_tostring_method.phpt
@@ -1,7 +1,7 @@
 --TEST--
 removing magic __tostring method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_remove_magic_unserialize_method.phpt
+++ b/tests/runkit_remove_magic_unserialize_method.phpt
@@ -1,7 +1,7 @@
 --TEST--
 removing magic unserialize method
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 ?>
 --FILE--
 <?php

--- a/tests/runkit_sandbox_output_handler.phpt
+++ b/tests/runkit_sandbox_output_handler.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_sandbox_output_handler() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) print "skip"; 
       /* May not be available due to lack of TSRM interpreter support */
       if(!function_exists("runkit_sandbox_output_handler")) print "skip"; ?>
 --FILE--

--- a/tests/runkit_sandbox_with_register_globals.phpt
+++ b/tests/runkit_sandbox_with_register_globals.phpt
@@ -2,7 +2,7 @@
 Runkit_Sandbox with register_globals
 --SKIPIF--
 <?php
-  if(!extension_loaded("runkit") || !RUNKIT_FEATURE_SANDBOX) echo "skip";
+  if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_SANDBOX) echo "skip";
   if(version_compare(PHP_VERSION, '5.3.999', '>')) echo "skip";
 ?>
 --INI--

--- a/tests/runkit_static_property_add.phpt
+++ b/tests/runkit_static_property_add.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() function for static properties
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
 	  if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_static_property_add_existing.phpt
+++ b/tests/runkit_static_property_add_existing.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() function for existing static properties
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_static_property_add_single.phpt
+++ b/tests/runkit_static_property_add_single.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_default_property_add() function - static override
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_static_property_add_to_subclasses.phpt
+++ b/tests/runkit_static_property_add_to_subclasses.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_static_property_add() add properties to subclasses
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip";
       if(!function_exists('runkit_default_property_add')) print "skip";
 ?>
 --INI--

--- a/tests/runkit_static_vars.phpt
+++ b/tests/runkit_static_vars.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Static Variables in runkit modified functions
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --FILE--
 <?php
 function orig() {

--- a/tests/runkit_superglobals.phpt
+++ b/tests/runkit_superglobals.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit.superglobal setting
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 display_errors=on
 runkit.superglobal=foo,bar

--- a/tests/runkit_superglobals_obj.phpt
+++ b/tests/runkit_superglobals_obj.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit.superglobal setting creates superglobals that can be referenced multiple ways.
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 <?php if(!extension_loaded("session")) print "skip - This test assumes \$_SESSION will exist, but the session extension isn't enabled/installed"; ?>
 --INI--
 display_errors=on

--- a/tests/runkit_superglobals_obj_7.phpt
+++ b/tests/runkit_superglobals_obj_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit.superglobal setting creates superglobals that can be referenced multiple ways. (new function name)
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 <?php if(!extension_loaded("session")) print "skip - This test assumes \$_SESSION will exist, but the session extension isn't enabled/installed"; ?>
 --INI--
 display_errors=on

--- a/tests/runkit_user_functions_on_shutdown.phpt
+++ b/tests/runkit_user_functions_on_shutdown.phpt
@@ -1,7 +1,7 @@
 --TEST--
 user-defined functions should remain after runkit's shutdown
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('session_start')) print "skip";
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION || !function_exists('session_start')) print "skip";
 ?>
 --INI--
 error_reporting=E_ALL

--- a/tests/runkit_zval_inspect.phpt
+++ b/tests/runkit_zval_inspect.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit_zval_inspect() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 error_reporting=E_ALL
 display_errors=on

--- a/tests/runkit_zval_inspect_7.phpt
+++ b/tests/runkit_zval_inspect_7.phpt
@@ -1,7 +1,7 @@
 --TEST--
 runkit7_zval_inspect() function
 --SKIPIF--
-<?php if(!extension_loaded("runkit") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
+<?php if(!extension_loaded("runkit7") || !RUNKIT7_FEATURE_MANIPULATION) print "skip"; ?>
 --INI--
 error_reporting=E_ALL
 display_errors=on

--- a/tests/spl_object_id.phpt
+++ b/tests/spl_object_id.phpt
@@ -3,7 +3,7 @@ spl_object_id should fetch the object handle.
 --SKIPIF--
 <?php
 if (PHP_VERSION_ID >= 70200) exit("skip redundant test in php 7.2");
-if (!extension_loaded("runkit")) exit("skip");
+if (!extension_loaded("runkit7")) exit("skip");
 if (!function_exists("spl_object_id")) exit("skip");
 ?>
 --INI--


### PR DESCRIPTION
Runkit7 3.0 finishes changing this extension's name from "runkit" to "runkit7".
THIS WILL REQUIRE CHANGES TO YOUR BUILD SCRIPTS AND PHP.INI FILES.
This change was made at the request of PECL admins, to comply with naming and packaging standards.

- The compiled shared object name has been changed from `runkit.so` to `runkit7.so` (Mac/Linux) and `php_runkit.dll` to `php_runkit7.dll` (Windows)
  (php.ini files should be changed to reference `extension=runkit7.so` or `extension=php_runkit7.dll`)
- The configure flag names have been changed from flags such as `--enable-runkit` / `--enable-runkit-modify` to `--enable-runkit7` / `--enable-runkit7-modify`
- Code using `extension_loaded('runkit')` should be changed to `extension_loaded('runkit7')` (as well as uses of ReflectionExtension, etc.)
- The ini options `runkit.superglobal` and `runkit.internal_override` are unaffected.

Other changes:
- Classkit compatibility functions/constants have been removed.
- Superglobal support can now be disabled