### PR TITLE
Fix for runkit7_function_copy with runkit7.internal_override=1

### DIFF
--- a/ci/install_php_nts.sh
+++ b/ci/install_php_nts.sh
@@ -25,12 +25,8 @@ if [[ "x${TRAVIS:-0}" != "x" ]]; then
 fi
 # Otherwise, put a minimal installation inside of the cache.
 PHP_TAR_FILE="$PHP_FOLDER.tar.bz2"
-if [[ "$PHP_NTS_NORMAL_VERSION" == "7.4.0" || "$PHP_NTS_NORMAL_VERSION" == "8.0.0" ]] ; then
-    if [[ "$PHP_NTS_NORMAL_VERSION" == "7.4.0" ]] ; then
-        GIT_BRANCH=PHP-7.4
-    else
-        GIT_BRANCH=master
-    fi
+if [[ "$PHP_NTS_NORMAL_VERSION" == "8.0.0" ]] ; then
+    GIT_BRANCH=PHP-8.0
     curl --location --verbose https://github.com/php/php-src/archive/$GIT_BRANCH.zip -o php-src-$GIT_BRANCH.zip
     unzip -q php-src-$GIT_BRANCH.zip
     PHP_FOLDER=php-src-$GIT_BRANCH

--- a/package.xml
+++ b/package.xml
@@ -17,8 +17,8 @@ Define customized superglobal variables for general purpose use.
  </lead>
  <date>2020-10-08</date>
  <version>
-  <release>4.0.0a2</release>
-  <api>4.0.1</api>
+  <release>4.0.0dev</release>
+  <api>4.0.2dev</api>
  </version>
  <stability>
   <release>alpha</release>
@@ -26,8 +26,8 @@ Define customized superglobal variables for general purpose use.
  </stability>
  <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
  <notes>
-- Fix build failure in PECL releases due to missing files in the 4.0.0a1 archive.
-- Properly reference count references to file names in php 8.0 when copying functions
+- Fix edge case copying internal functions in runkit7_function_redefine
+- Avoid conflicts with other extensions that use reserved memory slots for internal function definitions.
  </notes>
  <contents>
   <dir name="/">
@@ -106,6 +106,7 @@ Define customized superglobal variables for general purpose use.
     <file name="runkit_function_redefine_and_doc_comment.phpt" role="test" />
     <file name="runkit_function_redefine_and_reflection.phpt" role="test" />
     <file name="runkit_function_redefine_and_revert.phpt" role="test" />
+    <file name="runkit_function_redefine_and_revert_closure.phpt" role="test" />
     <file name="runkit_function_redefine_closure_and_doc_comment.phpt" role="test" />
     <file name="runkit_function_redefine_closure_and_doc_comment_from_closure.phpt" role="test" />
     <file name="runkit_function_redefine_closure_static.phpt" role="test" />
@@ -228,6 +229,22 @@ Define customized superglobal variables for general purpose use.
  <providesextension>runkit7</providesextension>
  <extsrcrelease />
  <changelog>
+  <release>
+   <date>2020-10-08</date>
+   <version>
+    <release>4.0.0a2</release>
+    <api>4.0.1</api>
+   </version>
+   <stability>
+    <release>alpha</release>
+    <api>alpha</api>
+   </stability>
+   <license uri="http://www.opensource.org/licenses/BSD-3-Clause">BSD License (3 Clause)</license>
+   <notes>
+- Fix build failure in PECL releases due to missing files in the 4.0.0a1 archive.
+- Properly reference count references to file names in php 8.0 when copying functions
+   </notes>
+  </release>
   <release>
    <date>2020-10-08</date>
    <version>

--- a/runkit.c
+++ b/runkit.c
@@ -16,6 +16,7 @@
 */
 
 #include "runkit.h"
+#include "Zend/zend_extensions.h"
 #include "SAPI.h"
 
 /* PHP 8.0+ allows extensions to see the representation of default values. Older versions don't. */
@@ -209,6 +210,16 @@ static void php_runkit7_globals_ctor(void *pDest)
 	runkit_global->removed_method_str = "__method_removed_by_runkit__";
 	runkit_global->removed_function_str = "__function_removed_by_runkit__";
 	runkit_global->removed_parameter_str = "__parameter_removed_by_runkit__";
+#if defined(PHP_RUNKIT_MANIPULATION)
+#if PHP_VERSION_ID >= 80000
+	runkit_global->original_func_resource_handle = zend_get_resource_handle("runkit7");
+#else
+	{
+		zend_extension placeholder = {0};
+		runkit_global->original_func_resource_handle = zend_get_resource_handle(&placeholder);
+	}
+#endif
+#endif
 
 	_php_runkit_init_stub_function("__function_removed_by_runkit__", ZEND_FN(_php_runkit_removed_function), &runkit_global->removed_function);
 	_php_runkit_init_stub_function("__method_removed_by_runkit__", ZEND_FN(_php_runkit_removed_method), &runkit_global->removed_method);

--- a/runkit.h
+++ b/runkit.h
@@ -62,7 +62,7 @@ static inline void *_debug_emalloc(void *data, int bytes, char *file, int line)
 #define debug_printf(...) do { } while(0)
 #endif
 
-#define PHP_RUNKIT7_VERSION					"4.0.0a2"
+#define PHP_RUNKIT7_VERSION					"4.0.0dev"
 
 #define PHP_RUNKIT_OVERRIDE_OBJECTS           0x8000
 
@@ -143,6 +143,7 @@ ZEND_BEGIN_MODULE_GLOBALS(runkit7)
 	const char *name_str, *removed_method_str, *removed_function_str, *removed_parameter_str;
 	zend_function *removed_function, *removed_method;
 	zend_bool module_moved_to_front;
+	int original_func_resource_handle;
 #endif
 ZEND_END_MODULE_GLOBALS(runkit7)
 #endif

--- a/tests/runkit_function_redefine_and_revert_closure.phpt
+++ b/tests/runkit_function_redefine_and_revert_closure.phpt
@@ -12,7 +12,9 @@ runkit.internal_override=On
 for ($i = 0; $i < 3; $i++) {
     echo sprintf("%s\n",'bar');
     runkit7_function_copy('sprintf','sprintf_old');
-    runkit7_function_redefine('sprintf','$a,$b', 'return "new function\n" . sprintf_old($a,$b);');
+    runkit7_function_redefine('sprintf', function (string $a, string $b): string {
+        return "new function\n" . sprintf_old($a,$b);
+    });
     echo sprintf("%s\n",'bar');
     echo "Done call\n";
     runkit7_function_remove('sprintf');
@@ -53,3 +55,5 @@ calling original sprintf
 Done call to copy
 before removing sprintf_old:foo
 foo
+--XFAIL--
+Expected to fail because this bug was just discovered with runkit.internal_override and functions from closures.


### PR DESCRIPTION
The argument info was used after the function was freed

Closes #247